### PR TITLE
D8NID-267 ~ fix deprecated code warnings

### DIFF
--- a/nidirect_common/tests/src/Functional/DrivingInstructorTest.php
+++ b/nidirect_common/tests/src/Functional/DrivingInstructorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\cnnic_common\Functional;
+namespace Drupal\Tests\nidirect_common\Functional;
 
 use Drupal\Tests\BrowserTestBase;
 use Drupal\node\Entity\Node;

--- a/nidirect_common/tests/src/Functional/GPPracticeTest.php
+++ b/nidirect_common/tests/src/Functional/GPPracticeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\cnnic_common\Functional;
+namespace Drupal\Tests\nidirect_common\Functional;
 
 use Drupal\Tests\BrowserTestBase;
 use Drupal\node\Entity\Node;

--- a/nidirect_gp/src/Controller/GpController.php
+++ b/nidirect_gp/src/Controller/GpController.php
@@ -26,7 +26,7 @@ class GpController extends ControllerBase implements ContainerInjectionInterface
    *   An array suitable for drupal_render().
    */
   public function revisionShow($gp_revision) {
-    $gp = \Drupal::entityTypeManager()->getStorage('gp')->loadRevision($gp_revision);
+    $gp = $this->container()->get('entity.manager')->getStorage('gp')->loadRevision($gp_revision);
     $view_builder = \Drupal::entityTypeManager()->getViewBuilder('gp');
 
     return $view_builder->view($gp);

--- a/nidirect_gp/src/Controller/GpController.php
+++ b/nidirect_gp/src/Controller/GpController.php
@@ -66,12 +66,8 @@ class GpController extends ControllerBase implements ContainerInjectionInterface
     $has_translations = (count($languages) > 1);
     $gp_storage = \Drupal::entityTypeManager()->getStorage('gp');
 
-    $build['#title'] = $has_translations ? $this->t('@langname revisions for %title', [
-      '@langname' => $langname,
-      '%title' => $gp->label()]) : $this->t('Revisions for %title', ['%title' => $gp->label()
-    ]);
+    $build['#title'] = $has_translations ? $this->t('@langname revisions for %title', ['@langname' => $langname, '%title' => $gp->label()]) : $this->t('Revisions for %title', ['%title' => $gp->label()]);
     $header = [$this->t('Revision'), $this->t('Operations')];
-
     $revert_permission = (($account->hasPermission("revert all gp revisions") || $account->hasPermission('administer gp entities')));
     $delete_permission = (($account->hasPermission("delete all gp revisions") || $account->hasPermission('administer gp entities')));
 

--- a/nidirect_gp/src/Controller/GpController.php
+++ b/nidirect_gp/src/Controller/GpController.php
@@ -26,7 +26,7 @@ class GpController extends ControllerBase implements ContainerInjectionInterface
    *   An array suitable for drupal_render().
    */
   public function revisionShow($gp_revision) {
-    $gp = $this->container()->get('entity.manager')->getStorage('gp')->loadRevision($gp_revision);
+    $gp = $this->entityTypeManager()->getStorage('gp')->loadRevision($gp_revision);
     $view_builder = $this->entityTypeManager()->getViewBuilder('gp');
 
     return $view_builder->view($gp);

--- a/nidirect_gp/src/Controller/GpController.php
+++ b/nidirect_gp/src/Controller/GpController.php
@@ -27,7 +27,7 @@ class GpController extends ControllerBase implements ContainerInjectionInterface
    */
   public function revisionShow($gp_revision) {
     $gp = $this->container()->get('entity.manager')->getStorage('gp')->loadRevision($gp_revision);
-    $view_builder = \Drupal::entityTypeManager()->getViewBuilder('gp');
+    $view_builder = $this->entityTypeManager()->getViewBuilder('gp');
 
     return $view_builder->view($gp);
   }
@@ -42,7 +42,7 @@ class GpController extends ControllerBase implements ContainerInjectionInterface
    *   The page title.
    */
   public function revisionPageTitle($gp_revision) {
-    $gp = \Drupal::entityTypeManager()->getStorage('gp')->loadRevision($gp_revision);
+    $gp = $this->entityTypeManager()->getStorage('gp')->loadRevision($gp_revision);
     return $this->t('Revision of %title from %date', [
       '%title' => $gp->label(),
       '%date' => \Drupal::service('date.formatter')->format($gp->getRevisionCreationTime())
@@ -64,7 +64,7 @@ class GpController extends ControllerBase implements ContainerInjectionInterface
     $langname = $gp->language()->getName();
     $languages = $gp->getTranslationLanguages();
     $has_translations = (count($languages) > 1);
-    $gp_storage = \Drupal::entityTypeManager()->getStorage('gp');
+    $gp_storage = $this->entityTypeManager()->getStorage('gp');
 
     $build['#title'] = $has_translations ? $this->t('@langname revisions for %title', ['@langname' => $langname, '%title' => $gp->label()]) : $this->t('Revisions for %title', ['%title' => $gp->label()]);
     $header = [$this->t('Revision'), $this->t('Operations')];

--- a/nidirect_gp/src/Form/GpForm.php
+++ b/nidirect_gp/src/Form/GpForm.php
@@ -4,6 +4,7 @@ namespace Drupal\nidirect_gp\Form;
 
 use Drupal\Core\Entity\ContentEntityForm;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
 
 /**
  * Form controller for GP edit forms.
@@ -55,13 +56,13 @@ class GpForm extends ContentEntityForm {
 
     switch ($status) {
       case SAVED_NEW:
-        drupal_set_message($this->t('Created GP %label.', [
+        MessengerInterface::addMessage($this->t('Created GP %label.', [
           '%label' => $entity->label(),
         ]));
         break;
 
       default:
-        drupal_set_message($this->t('Saved GP %label.', [
+        MessengerInterface::addMessage($this->t('Saved GP %label.', [
           '%label' => $entity->label(),
         ]));
     }

--- a/nidirect_gp/src/Form/GpForm.php
+++ b/nidirect_gp/src/Form/GpForm.php
@@ -5,6 +5,10 @@ namespace Drupal\nidirect_gp\Form;
 use Drupal\Core\Entity\ContentEntityForm;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Messenger\MessengerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Component\Datetime\TimeInterface;
 
 /**
  * Form controller for GP edit forms.
@@ -12,6 +16,33 @@ use Drupal\Core\Messenger\MessengerInterface;
  * @ingroup nidirect_gp
  */
 class GpForm extends ContentEntityForm {
+
+  /**
+   * The Messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(EntityRepositoryInterface $entity_repository, EntityTypeBundleInfoInterface $entity_type_bundle_info = NULL, TimeInterface $time = NULL, MessengerInterface $messenger = NULL) {
+    $this->messenger = $messenger;
+    parent::__construct($entity_repository, $entity_type_bundle_info, $time);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity.repository'),
+      $container->get('entity_type.bundle.info'),
+      $container->get('datetime.time'),
+      $container->get('messenger')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -56,13 +87,13 @@ class GpForm extends ContentEntityForm {
 
     switch ($status) {
       case SAVED_NEW:
-        MessengerInterface::addMessage($this->t('Created GP %label.', [
+        $this->messenger->addMessage($this->t('Created GP %label.', [
           '%label' => $entity->label(),
         ]));
         break;
 
       default:
-        MessengerInterface::addMessage($this->t('Saved GP %label.', [
+        $this->messenger->addMessage($this->t('Saved GP %label.', [
           '%label' => $entity->label(),
         ]));
     }

--- a/nidirect_gp/src/Form/GpRevisionDeleteForm.php
+++ b/nidirect_gp/src/Form/GpRevisionDeleteForm.php
@@ -3,6 +3,7 @@
 namespace Drupal\nidirect_gp\Form;
 
 use Drupal\Core\Database\Connection;
+use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -17,6 +18,19 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  */
 class GpRevisionDeleteForm extends ConfirmFormBase {
 
+  /**
+   * The Messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * Date formatter service.
+   *
+   * @var \Drupal\Core\Datetime\DateFormatterInterface
+   */
+  protected $dateFormatter;
 
   /**
    * The GP revision.
@@ -30,7 +44,7 @@ class GpRevisionDeleteForm extends ConfirmFormBase {
    *
    * @var \Drupal\Core\Entity\EntityStorageInterface
    */
-  protected $GpStorage;
+  protected $entity_storage;
 
   /**
    * The database connection.
@@ -46,10 +60,14 @@ class GpRevisionDeleteForm extends ConfirmFormBase {
    *   The entity storage.
    * @param \Drupal\Core\Database\Connection $connection
    *   The database connection.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   Drupal messenger service.
    */
-  public function __construct(EntityStorageInterface $entity_storage, Connection $connection) {
-    $this->GpStorage = $entity_storage;
+  public function __construct(EntityStorageInterface $entity_storage, Connection $connection, MessengerInterface $messenger = NULL, DateFormatterInterface $date_formatter) {
+    $this->entity_storage = $entity_storage;
     $this->connection = $connection;
+    $this->messenger = $messenger;
+    $this->dateFormatter = $date_formatter;
   }
 
   /**
@@ -59,7 +77,9 @@ class GpRevisionDeleteForm extends ConfirmFormBase {
     $entity_manager = $container->get('entity.manager');
     return new static(
       $entity_manager->getStorage('gp'),
-      $container->get('database')
+      $container->get('database'),
+      $container->get('messenger'),
+      $container->get('date.formatter')
     );
   }
 
@@ -74,7 +94,7 @@ class GpRevisionDeleteForm extends ConfirmFormBase {
    * {@inheritdoc}
    */
   public function getQuestion() {
-    return t('Are you sure you want to delete the revision from %revision-date?', ['%revision-date' => \Drupal::service('date.formatter')->format($this->revision->getRevisionCreationTime())]);
+    return t('Are you sure you want to delete the revision from %revision-date?', ['%revision-date' => $this->dateFormatter->format($this->revision->getRevisionCreationTime())]);
   }
 
   /**
@@ -95,7 +115,7 @@ class GpRevisionDeleteForm extends ConfirmFormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state, $gp_revision = NULL) {
-    $this->revision = $this->GpStorage->loadRevision($gp_revision);
+    $this->revision = $this->entity_storage->loadRevision($gp_revision);
     $form = parent::buildForm($form, $form_state);
 
     return $form;
@@ -105,10 +125,10 @@ class GpRevisionDeleteForm extends ConfirmFormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    $this->GpStorage->deleteRevision($this->revision->getRevisionId());
+    $this->entity_storage->deleteRevision($this->revision->getRevisionId());
 
     $this->logger('content')->notice('GP: deleted %title revision %revision.', ['%title' => $this->revision->label(), '%revision' => $this->revision->getRevisionId()]);
-    MessengerInterface::addMessage(t('Revision from %revision-date of GP %title has been deleted.', ['%revision-date' => \Drupal::service('date.formatter')->format($this->revision->getRevisionCreationTime()), '%title' => $this->revision->label()]));
+    $this->messenger->addMessage(t('Revision from %revision-date of GP %title has been deleted.', ['%revision-date' => $this->dateFormatter->format($this->revision->getRevisionCreationTime()), '%title' => $this->revision->label()]));
     $form_state->setRedirect(
       'entity.gp.canonical',
        ['gp' => $this->revision->id()]

--- a/nidirect_gp/src/Form/GpRevisionDeleteForm.php
+++ b/nidirect_gp/src/Form/GpRevisionDeleteForm.php
@@ -6,6 +6,7 @@ use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Url;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -73,7 +74,7 @@ class GpRevisionDeleteForm extends ConfirmFormBase {
    * {@inheritdoc}
    */
   public function getQuestion() {
-    return t('Are you sure you want to delete the revision from %revision-date?', ['%revision-date' => format_date($this->revision->getRevisionCreationTime())]);
+    return t('Are you sure you want to delete the revision from %revision-date?', ['%revision-date' => \Drupal::service('date.formatter')->format($this->revision->getRevisionCreationTime())]);
   }
 
   /**
@@ -107,7 +108,7 @@ class GpRevisionDeleteForm extends ConfirmFormBase {
     $this->GpStorage->deleteRevision($this->revision->getRevisionId());
 
     $this->logger('content')->notice('GP: deleted %title revision %revision.', ['%title' => $this->revision->label(), '%revision' => $this->revision->getRevisionId()]);
-    drupal_set_message(t('Revision from %revision-date of GP %title has been deleted.', ['%revision-date' => format_date($this->revision->getRevisionCreationTime()), '%title' => $this->revision->label()]));
+    MessengerInterface::addMessage(t('Revision from %revision-date of GP %title has been deleted.', ['%revision-date' => \Drupal::service('date.formatter')->format($this->revision->getRevisionCreationTime()), '%title' => $this->revision->label()]));
     $form_state->setRedirect(
       'entity.gp.canonical',
        ['gp' => $this->revision->id()]

--- a/nidirect_gp/src/Form/GpRevisionRevertForm.php
+++ b/nidirect_gp/src/Form/GpRevisionRevertForm.php
@@ -6,6 +6,7 @@ use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Url;
 use Drupal\nidirect_gp\Entity\GpInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -120,7 +121,7 @@ class GpRevisionRevertForm extends ConfirmFormBase {
     $this->revision->save();
 
     $this->logger('content')->notice('GP: reverted %title revision %revision.', ['%title' => $this->revision->label(), '%revision' => $this->revision->getRevisionId()]);
-    drupal_set_message(t('GP %title has been reverted to the revision from %revision-date.', ['%title' => $this->revision->label(), '%revision-date' => $this->dateFormatter->format($original_revision_timestamp)]));
+    MessengerInterface::addMessage(t('GP %title has been reverted to the revision from %revision-date.', ['%title' => $this->revision->label(), '%revision-date' => $this->dateFormatter->format($original_revision_timestamp)]));
     $form_state->setRedirect(
       'entity.gp.version_history',
       ['gp' => $this->revision->id()]

--- a/nidirect_school_closures/src/SchoolClosure.php
+++ b/nidirect_school_closures/src/SchoolClosure.php
@@ -26,6 +26,18 @@ class SchoolClosure {
     "flooding or burst pipes"                                                     => "due to flooding or a burst pipe.",
   ];
 
+  /**
+   * Constructor.
+   *
+   * @param string $name
+   *   Name of the closure.
+   * @param string $location
+   *   Closure location.
+   * @param \DateTime $date
+   *   Date of closure.
+   * @param string $reason
+   *   Reason for closure.
+   */
   public function __construct(string $name, string $location, \DateTime $date, string $reason) {
     $this->name = $name;
     $this->location = $location;

--- a/nidirect_school_closures/tests/src/Kernel/C2kschoolsSchoolClosuresServiceTest.php
+++ b/nidirect_school_closures/tests/src/Kernel/C2kschoolsSchoolClosuresServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\nidirect_school_closures;
+namespace Drupal\Tests\nidirect_school_closures\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
 

--- a/nidirect_school_closures/tests/src/Kernel/SchoolClosuresTest.php
+++ b/nidirect_school_closures/tests/src/Kernel/SchoolClosuresTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\nidirect_school_closures;
+namespace Drupal\Tests\nidirect_school_closures\Kernel;
 
 use Drupal\nidirect_school_closures\SchoolClosure;
 use Drupal\KernelTests\KernelTestBase;

--- a/nidirect_workflow/nidirect_workflow.module
+++ b/nidirect_workflow/nidirect_workflow.module
@@ -1,6 +1,10 @@
 <?php
 
 /**
+ * @file
+ */
+
+/**
  * Implements hook_page_attachments().
  */
 function nidirect_workflow_page_attachments(array &$attachments) {


### PR DESCRIPTION
drupal-check and phpcs were throwing errors about some deprecated code, autoloading of classes and code not compliant with drupal.org coding standards.

This PR aims to fix those. Has been validated with:

`lando drck drupal8/web/modules/custom`

and

`lando phpcs`