### PR TITLE
D8 nid 259

### DIFF
--- a/nidirect_common/tests/src/Functional/DrivingInstructorTest.php
+++ b/nidirect_common/tests/src/Functional/DrivingInstructorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\cnnic_common\Functional;
+namespace Drupal\Tests\nidirect_common\Functional;
 
 use Drupal\Tests\BrowserTestBase;
 use Drupal\node\Entity\Node;

--- a/nidirect_common/tests/src/Functional/DrivingInstructorTest.php
+++ b/nidirect_common/tests/src/Functional/DrivingInstructorTest.php
@@ -38,10 +38,10 @@ class DrivingInstructorTest extends BrowserTestBase {
       'field_di_adi_no' => [['value' => '222']],
     ]);
     $this->assertTrue(Node::load($node->id()), 'Node created.');
-    $this->drupalGet('/node/' . $node->id() . '/view');
+    $new_node = Node::load($node->id());
     // Node title should have been automatically set to include
     // all three fields.
-    $this->assertSession()->pageTextContains('Firstname Lastname (ADI No. 222)');
+    $this->assertEquals('Firstname Lastname (ADI No. 222)', $new_node->getTitle());
   }
 
 }

--- a/nidirect_common/tests/src/Functional/GPPracticeTest.php
+++ b/nidirect_common/tests/src/Functional/GPPracticeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\cnnic_common\Functional;
+namespace Drupal\Tests\nidirect_common\Functional;
 
 use Drupal\Tests\BrowserTestBase;
 use Drupal\node\Entity\Node;

--- a/nidirect_common/tests/src/Functional/GPPracticeTest.php
+++ b/nidirect_common/tests/src/Functional/GPPracticeTest.php
@@ -37,10 +37,12 @@ class GPPracticeTest extends BrowserTestBase {
       'field_gp_surgery_name' => [['value' => 'Surgery']],
     ]);
     $this->assertTrue(Node::load($node->id()), 'Node created.');
-    $this->drupalGet('/node/' . $node->id() . '/view');
+
+    $this->assertTrue(Node::load($node->id()), 'Node created.');
+    $new_node = Node::load($node->id());
     // Node title should have been automatically set to include
     // both fields.
-    $this->assertSession()->pageTextContains('Surgery - Practice');
+    $this->assertEquals('Surgery - Practice', $new_node->getTitle());
   }
 
   /**
@@ -53,12 +55,10 @@ class GPPracticeTest extends BrowserTestBase {
       'field_gp_practice_name' => [['value' => 'Practice']]
     ]);
     $this->assertTrue(Node::load($node->id()), 'Node created.');
-    $this->drupalGet('/node/' . $node->id() . '/view');
+    $new_node = Node::load($node->id());
     // Node title should have been automatically set to include
     // the practice name.
-    $this->assertSession()->pageTextContains('Practice');
-    // There should be no hyphen.
-    $this->assertSession()->pageTextNotContains('- Practice');
+    $this->assertEquals('Practice', $new_node->getTitle());
 
     // Create a node with the other field filled in.
     $node = $this->drupalCreateNode([
@@ -66,12 +66,10 @@ class GPPracticeTest extends BrowserTestBase {
       'field_gp_surgery_name' => [['value' => 'Surgery']]
     ]);
     $this->assertTrue(Node::load($node->id()), 'Node created.');
-    $this->drupalGet('/node/' . $node->id() . '/view');
+    $new_node = Node::load($node->id());
     // Node title should have been automatically set to include
     // the practice name.
-    $this->assertSession()->pageTextContains('Surgery');
-    // There should be no hyphen.
-    $this->assertSession()->pageTextNotContains('Surgery -');
+    $this->assertEquals('Surgery', $new_node->getTitle());
   }
 
 }

--- a/nidirect_common/tests/src/Kernel/DrivingInstructorTest.php
+++ b/nidirect_common/tests/src/Kernel/DrivingInstructorTest.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\Tests\nidirect_common\Kernel;
 
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
 use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\Node;
@@ -37,8 +39,51 @@ class DrivingInstructorTest extends EntityKernelTestBase {
     // Create a node to view.
     $content_admin_user = $this->createUser(['uid' => 2], ['administer nodes']);
 
+    // Create a node type for testing.
+    NodeType::create(['type' => 'driving_instructor',
+      'label' => 'driving_instructor'])->save();
+
+    // Add fields.
+    FieldStorageConfig::create([
+      'field_name' => 'field_di_firstname',
+      'type' => 'string',
+      'entity_type' => 'node',
+      'cardinality' => 1,
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'field_di_firstname',
+      'label' => 'field_di_firstname',
+      'entity_type' => 'node',
+      'bundle' => 'driving_instructor',
+    ])->save();
+
+    FieldStorageConfig::create([
+      'field_name' => 'field_di_lastname',
+      'type' => 'string',
+      'entity_type' => 'node',
+      'cardinality' => 1,
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'field_di_lastname',
+      'label' => 'field_di_lastname',
+      'entity_type' => 'node',
+      'bundle' => 'driving_instructor',
+    ])->save();
+
+    FieldStorageConfig::create([
+      'field_name' => 'field_di_adi_no',
+      'type' => 'string',
+      'entity_type' => 'node',
+      'cardinality' => 1,
+    ])->save();
+    FieldConfig::create([
+      'field_name' => 'field_di_adi_no',
+      'label' => 'field_di_adi_no',
+      'entity_type' => 'node',
+      'bundle' => 'driving_instructor',
+    ])->save();
+
     $ctype = NodeType::load('driving_instructor');
-    var_dump($ctype->id());
     $node = Node::create([
       'type' => 'driving_instructor',
       'field_di_firstname' => [['value' => 'Firstname']],
@@ -46,9 +91,12 @@ class DrivingInstructorTest extends EntityKernelTestBase {
       'field_di_adi_no' => [['value' => '222']],
       'uid' => $content_admin_user->id()
     ]);
-    //$node->save();
-    var_dump($node->getTitle());
-    $this->assertEquals('Firstname Lastname (ADI No. 222)', $node->getTitle());
+    $node->save();
+    $nid = $node->id();
+    $new_node = Node::load($nid);
+    $title = $new_node->getTitle();
+    $comp = "Firstname Lastname (ADI No. 222)";
+    $this->assertEquals('Firstname Lastname (ADI No. 222)', $title);
 
   }
 

--- a/nidirect_common/tests/src/Kernel/DrivingInstructorTest.php
+++ b/nidirect_common/tests/src/Kernel/DrivingInstructorTest.php
@@ -29,21 +29,11 @@ class DrivingInstructorTest extends EntityKernelTestBase {
   public function setUp() {
     parent::setUp();
 
-    $this->setInstallProfile('test_profile');
-  }
-
-  /**
-   * Tests the behavior when creating the node.
-   */
-  public function testNodeCreate() {
-    // Create a node to view.
-    $content_admin_user = $this->createUser(['uid' => 2], ['administer nodes']);
-
-    // Create a node type for testing.
+    // Create a mock node type for testing.
     NodeType::create(['type' => 'driving_instructor',
       'label' => 'driving_instructor'])->save();
 
-    // Add fields.
+    // Add mocked fields.
     $fields = ['field_di_firstname', 'field_di_lastname', 'field_di_adi_no'];
     foreach ($fields as $field) {
       FieldStorageConfig::create([
@@ -59,8 +49,14 @@ class DrivingInstructorTest extends EntityKernelTestBase {
         'bundle' => 'driving_instructor',
       ])->save();
     }
+  }
 
-    $ctype = NodeType::load('driving_instructor');
+  /**
+   * Tests the behavior when creating the node.
+   */
+  public function testNodeCreate() {
+    // Create a node to view.
+    $content_admin_user = $this->createUser(['uid' => 2], ['administer nodes']);
     $node = Node::create([
       'type' => 'driving_instructor',
       'field_di_firstname' => [['value' => 'Firstname']],

--- a/nidirect_common/tests/src/Kernel/DrivingInstructorTest.php
+++ b/nidirect_common/tests/src/Kernel/DrivingInstructorTest.php
@@ -5,7 +5,6 @@ namespace Drupal\Tests\nidirect_common\Kernel;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
-use Drupal\KernelTests\KernelTestBase;
 use Drupal\node\Entity\Node;
 use Drupal\node\Entity\NodeType;
 
@@ -30,8 +29,10 @@ class DrivingInstructorTest extends EntityKernelTestBase {
     parent::setUp();
 
     // Create a mock node type for testing.
-    NodeType::create(['type' => 'driving_instructor',
-      'label' => 'driving_instructor'])->save();
+    NodeType::create([
+      'type' => 'driving_instructor',
+      'label' => 'driving_instructor',
+    ])->save();
 
     // Add mocked fields.
     $fields = ['field_di_firstname', 'field_di_lastname', 'field_di_adi_no'];
@@ -62,11 +63,11 @@ class DrivingInstructorTest extends EntityKernelTestBase {
       'field_di_firstname' => [['value' => 'Firstname']],
       'field_di_lastname' => [['value' => 'Lastname']],
       'field_di_adi_no' => [['value' => '222']],
-      'uid' => $content_admin_user->id()
+      'uid' => $content_admin_user->id(),
     ]);
     $node->save();
+    // Title should have been automatically set to a combination of fields.
     $this->assertEquals('Firstname Lastname (ADI No. 222)', $node->getTitle());
-
   }
 
 }

--- a/nidirect_common/tests/src/Kernel/DrivingInstructorTest.php
+++ b/nidirect_common/tests/src/Kernel/DrivingInstructorTest.php
@@ -20,7 +20,7 @@ class DrivingInstructorTest extends EntityKernelTestBase {
    *
    * @var array
    */
-  public static $modules = ['user', 'node', 'nidirect_common'];
+  public static $modules = ['node', 'nidirect_common'];
 
   /**
    * Test setup function.

--- a/nidirect_common/tests/src/Kernel/DrivingInstructorTest.php
+++ b/nidirect_common/tests/src/Kernel/DrivingInstructorTest.php
@@ -92,11 +92,7 @@ class DrivingInstructorTest extends EntityKernelTestBase {
       'uid' => $content_admin_user->id()
     ]);
     $node->save();
-    $nid = $node->id();
-    $new_node = Node::load($nid);
-    $title = $new_node->getTitle();
-    $comp = "Firstname Lastname (ADI No. 222)";
-    $this->assertEquals('Firstname Lastname (ADI No. 222)', $title);
+    $this->assertEquals('Firstname Lastname (ADI No. 222)', $node->getTitle());
 
   }
 

--- a/nidirect_common/tests/src/Kernel/DrivingInstructorTest.php
+++ b/nidirect_common/tests/src/Kernel/DrivingInstructorTest.php
@@ -28,13 +28,13 @@ class DrivingInstructorTest extends EntityKernelTestBase {
   public function setUp() {
     parent::setUp();
 
-    // Create a mock node type for testing.
+    // Create a content type for testing.
     NodeType::create([
       'type' => 'driving_instructor',
       'label' => 'driving_instructor',
     ])->save();
 
-    // Add mocked fields.
+    // Add required fields.
     $fields = ['field_di_firstname', 'field_di_lastname', 'field_di_adi_no'];
     foreach ($fields as $field) {
       FieldStorageConfig::create([
@@ -56,7 +56,7 @@ class DrivingInstructorTest extends EntityKernelTestBase {
    * Tests the behavior when creating the node.
    */
   public function testNodeCreate() {
-    // Create a node to view.
+    // Create a driving instructor.
     $content_admin_user = $this->createUser(['uid' => 2], ['administer nodes']);
     $node = Node::create([
       'type' => 'driving_instructor',

--- a/nidirect_common/tests/src/Kernel/DrivingInstructorTest.php
+++ b/nidirect_common/tests/src/Kernel/DrivingInstructorTest.php
@@ -57,13 +57,11 @@ class DrivingInstructorTest extends EntityKernelTestBase {
    */
   public function testNodeCreate() {
     // Create a driving instructor.
-    $content_admin_user = $this->createUser(['uid' => 2], ['administer nodes']);
     $node = Node::create([
       'type' => 'driving_instructor',
       'field_di_firstname' => [['value' => 'Firstname']],
       'field_di_lastname' => [['value' => 'Lastname']],
       'field_di_adi_no' => [['value' => '222']],
-      'uid' => $content_admin_user->id(),
     ]);
     $node->save();
     // Title should have been automatically set to a combination of fields.

--- a/nidirect_common/tests/src/Kernel/DrivingInstructorTest.php
+++ b/nidirect_common/tests/src/Kernel/DrivingInstructorTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\Tests\nidirect_common\Kernel;
+
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+
+/**
+ * Tests Driving Instructor title generation.
+ *
+ * @group nidirect_common
+ */
+class DrivingInstructorTest extends EntityKernelTestBase {
+
+  /**
+   * Modules to install.
+   *
+   * @var array
+   */
+  public static $modules = ['user', 'node', 'nidirect_common'];
+
+  /**
+   * Test setup function.
+   */
+  public function setUp() {
+    parent::setUp();
+
+    $this->setInstallProfile('test_profile');
+  }
+
+  /**
+   * Tests the behavior when creating the node.
+   */
+  public function testNodeCreate() {
+    // Create a node to view.
+    $content_admin_user = $this->createUser(['uid' => 2], ['administer nodes']);
+
+    $ctype = NodeType::load('driving_instructor');
+    var_dump($ctype->id());
+    $node = Node::create([
+      'type' => 'driving_instructor',
+      'field_di_firstname' => [['value' => 'Firstname']],
+      'field_di_lastname' => [['value' => 'Lastname']],
+      'field_di_adi_no' => [['value' => '222']],
+      'uid' => $content_admin_user->id()
+    ]);
+    //$node->save();
+    var_dump($node->getTitle());
+    $this->assertEquals('Firstname Lastname (ADI No. 222)', $node->getTitle());
+
+  }
+
+}

--- a/nidirect_common/tests/src/Kernel/DrivingInstructorTest.php
+++ b/nidirect_common/tests/src/Kernel/DrivingInstructorTest.php
@@ -44,44 +44,21 @@ class DrivingInstructorTest extends EntityKernelTestBase {
       'label' => 'driving_instructor'])->save();
 
     // Add fields.
-    FieldStorageConfig::create([
-      'field_name' => 'field_di_firstname',
-      'type' => 'string',
-      'entity_type' => 'node',
-      'cardinality' => 1,
-    ])->save();
-    FieldConfig::create([
-      'field_name' => 'field_di_firstname',
-      'label' => 'field_di_firstname',
-      'entity_type' => 'node',
-      'bundle' => 'driving_instructor',
-    ])->save();
-
-    FieldStorageConfig::create([
-      'field_name' => 'field_di_lastname',
-      'type' => 'string',
-      'entity_type' => 'node',
-      'cardinality' => 1,
-    ])->save();
-    FieldConfig::create([
-      'field_name' => 'field_di_lastname',
-      'label' => 'field_di_lastname',
-      'entity_type' => 'node',
-      'bundle' => 'driving_instructor',
-    ])->save();
-
-    FieldStorageConfig::create([
-      'field_name' => 'field_di_adi_no',
-      'type' => 'string',
-      'entity_type' => 'node',
-      'cardinality' => 1,
-    ])->save();
-    FieldConfig::create([
-      'field_name' => 'field_di_adi_no',
-      'label' => 'field_di_adi_no',
-      'entity_type' => 'node',
-      'bundle' => 'driving_instructor',
-    ])->save();
+    $fields = ['field_di_firstname', 'field_di_lastname', 'field_di_adi_no'];
+    foreach ($fields as $field) {
+      FieldStorageConfig::create([
+        'field_name' => $field,
+        'type' => 'string',
+        'entity_type' => 'node',
+        'cardinality' => 1,
+      ])->save();
+      FieldConfig::create([
+        'field_name' => $field,
+        'label' => $field,
+        'entity_type' => 'node',
+        'bundle' => 'driving_instructor',
+      ])->save();
+    }
 
     $ctype = NodeType::load('driving_instructor');
     $node = Node::create([

--- a/nidirect_common/tests/src/Kernel/GPPracticeTest.php
+++ b/nidirect_common/tests/src/Kernel/GPPracticeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Tests\cnnic_common\Functional;
+namespace Drupal\Tests\nidirect_common\Kernel;
 
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;

--- a/nidirect_common/tests/src/Kernel/GPPracticeTest.php
+++ b/nidirect_common/tests/src/Kernel/GPPracticeTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Drupal\Tests\cnnic_common\Functional;
+
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\KernelTests\Core\Entity\EntityKernelTestBase;
+use Drupal\node\Entity\Node;
+use Drupal\node\Entity\NodeType;
+
+/**
+ * Tests Driving Instructor title generation.
+ *
+ * @group nidirect_common
+ */
+class GPPracticeTest extends EntityKernelTestBase {
+
+  /**
+   * Modules to install.
+   *
+   * @var array
+   */
+  public static $modules = ['nidirect_common', 'node'];
+
+  /**
+   * Test setup function.
+   */
+  public function setUp() {
+    parent::setUp();
+
+    // Create a content type for testing.
+    NodeType::create([
+      'type' => 'gp_practice',
+      'label' => 'gp_practice',
+    ])->save();
+
+    // Add required fields.
+    $fields = ['field_gp_practice_name', 'field_gp_surgery_name'];
+    foreach ($fields as $field) {
+      FieldStorageConfig::create([
+        'field_name' => $field,
+        'type' => 'string',
+        'entity_type' => 'node',
+        'cardinality' => 1,
+      ])->save();
+      FieldConfig::create([
+        'field_name' => $field,
+        'label' => $field,
+        'entity_type' => 'node',
+        'bundle' => 'gp_practice',
+      ])->save();
+    }
+  }
+
+  /**
+   * Tests the behavior when creating the node with two fields.
+   */
+  public function testVanillaNodeCreate() {
+    // Create a node to view.
+    $node = Node::create([
+      'type' => 'gp_practice',
+      'field_gp_practice_name' => [['value' => 'Practice']],
+      'field_gp_surgery_name' => [['value' => 'Surgery']],
+    ]);
+    $node->save();
+    $this->assertEquals('Surgery - Practice', $node->getTitle());
+  }
+
+  /**
+   * Tests the behavior when creating the node with one field.
+   */
+  public function testOneFieldNodeCreate() {
+    // Create a node with just one field filled in.
+    $node = Node::create([
+      'type' => 'gp_practice',
+      'field_gp_practice_name' => [['value' => 'Practice']]
+    ]);
+    $node->save();
+    $this->assertEquals('Practice', $node->getTitle());
+
+    /*// Create a node with the other field filled in.
+    $node = $this->drupalCreateNode([
+      'type' => 'gp_practice',
+      'field_gp_surgery_name' => [['value' => 'Surgery']]
+    ]);
+    $this->assertTrue(Node::load($node->id()), 'Node created.');
+    $this->drupalGet('/node/' . $node->id() . '/view');
+    // Node title should have been automatically set to include
+    // the practice name.
+    $this->assertSession()->pageTextContains('Surgery');
+    // There should be no hyphen.
+    $this->assertSession()->pageTextNotContains('Surgery -');*/
+  }
+
+}

--- a/nidirect_common/tests/src/Kernel/GPPracticeTest.php
+++ b/nidirect_common/tests/src/Kernel/GPPracticeTest.php
@@ -78,18 +78,13 @@ class GPPracticeTest extends EntityKernelTestBase {
     $node->save();
     $this->assertEquals('Practice', $node->getTitle());
 
-    /*// Create a node with the other field filled in.
-    $node = $this->drupalCreateNode([
+    // Create a node with the other field filled in.
+    $node = Node::create([
       'type' => 'gp_practice',
-      'field_gp_surgery_name' => [['value' => 'Surgery']]
+      'field_gp_practice_name' => [['value' => 'Surgery']]
     ]);
-    $this->assertTrue(Node::load($node->id()), 'Node created.');
-    $this->drupalGet('/node/' . $node->id() . '/view');
-    // Node title should have been automatically set to include
-    // the practice name.
-    $this->assertSession()->pageTextContains('Surgery');
-    // There should be no hyphen.
-    $this->assertSession()->pageTextNotContains('Surgery -');*/
+    $node->save();
+    $this->assertEquals('Surgery', $node->getTitle());
   }
 
 }


### PR DESCRIPTION
Create Kernel tests for GP Practice and Driving Instructors.
Corrections to existing browser tests.
Left browser tests in place as Kernel tests required mocking of content type and fields.