### PR TITLE
D8 nid 87

### DIFF
--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -51,14 +51,30 @@ function nidirect_common_entity_presave(EntityInterface $entity) {
         $entity->setTitle($title);
         break;
 
+      case 'article':
+      case 'contact':
+      case 'page':
+        // We have just published a node type that is subject to auditing.
+        if ($entity->isPublished()) {
+          $next_audit_date = $entity->get('field_next_audit_due')->value;
+          if (empty($next_audit_date)) {
+            // No audit date set, set it for six months time.
+            $entity->set('field_next_audit_due',date('Y-m-d', strtotime("+6 months")));
+          }
+        }
+        // - Need to create a page that confirms removal of audit 'flag'
+        // - Need to add the 'audit this content' link to the node view page
+        // - Need to restrict access to the field in node edit.
+        break;
+
       case 'health_condition':
         if ($entity->isPublished()) {
-
-          // Need more logic in here !!
+          // Has a 'next review' date been set ?
           $review_date = $entity->get('field_next_review_date')->value;
-          // Flag for audit
-          $audit_flag = Flag::load('content_audit');
-          \Drupal::service('flag')->flag($audit_flag, $entity);
+          if (!empty($review_date)) {
+            // Set 'audit due' date to be the same.
+            $next_audit_date = $entity->get('field_next_audit_due')->value;
+          }
         }
 
     }

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -53,6 +53,9 @@ function nidirect_common_entity_presave(EntityInterface $entity) {
 
       case 'health_condition':
         if ($entity->isPublished()) {
+
+          // Need more logic in here !!
+          $review_date = $entity->get('field_next_review_date')->value;
           // Flag for audit
           $audit_flag = Flag::load('content_audit');
           \Drupal::service('flag')->flag($audit_flag, $entity);

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -50,33 +50,6 @@ function nidirect_common_entity_presave(EntityInterface $entity) {
         $title = build_gp_practice_title($practice, $surgery);
         $entity->setTitle($title);
         break;
-
-      case 'article':
-      case 'contact':
-      case 'page':
-        // We have just published a node type that is subject to auditing.
-        if ($entity->isPublished()) {
-          $next_audit_date = $entity->get('field_next_audit_due')->value;
-          if (empty($next_audit_date)) {
-            // No audit date set, set it for six months time.
-            $entity->set('field_next_audit_due',date('Y-m-d', strtotime("+6 months")));
-          }
-        }
-        // - Need to create a page that confirms removal of audit 'flag'
-        // - Need to add the 'audit this content' link to the node view page
-        // - Need to restrict access to the field in node edit.
-        break;
-
-      case 'health_condition':
-        if ($entity->isPublished()) {
-          // Has a 'next review' date been set ?
-          $review_date = $entity->get('field_next_review_date')->value;
-          if (!empty($review_date)) {
-            // Set 'audit due' date to be the same.
-            $next_audit_date = $entity->get('field_next_audit_due')->value;
-          }
-        }
-
     }
     /*
      * Programmatically sets the field_top_level_theme based on

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -49,6 +49,7 @@ function nidirect_common_entity_presave(EntityInterface $entity) {
         $title = build_gp_practice_title($practice, $surgery);
         $entity->setTitle($title);
         break;
+
     }
     /*
      * Programmatically sets the field_top_level_theme based on

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -9,7 +9,6 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Component\Utility\Xss;
-use Drupal\flag\Entity\Flag;
 
 /**
  * Implements hook_help().

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -9,6 +9,7 @@ use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Component\Utility\Xss;
+use Drupal\flag\Entity\Flag;
 
 /**
  * Implements hook_help().
@@ -49,6 +50,13 @@ function nidirect_common_entity_presave(EntityInterface $entity) {
         $title = build_gp_practice_title($practice, $surgery);
         $entity->setTitle($title);
         break;
+
+      case 'health_condition':
+        if ($entity->isPublished()) {
+          // Flag for audit
+          $audit_flag = Flag::load('content_audit');
+          \Drupal::service('flag')->flag($audit_flag, $entity);
+        }
 
     }
     /*

--- a/nidirect_workflow/nidirect_workflow.links.menu.yml
+++ b/nidirect_workflow/nidirect_workflow.links.menu.yml
@@ -34,3 +34,10 @@ nidirect_workflow.needs_audit:
   description: 'Needs Audit'
   parent: nidirect_workflow.my_workbench
   weight: 4
+nidirect_workflow.audit_settings_form:
+  title: 'NIDirect Audit Settings Form'
+  route_name: nidirect_workflow.audit_settings_form
+  description: 'Configure audit settings and messages'
+  parent: system.admin_config_system
+  weight: 99
+

--- a/nidirect_workflow/nidirect_workflow.links.menu.yml
+++ b/nidirect_workflow/nidirect_workflow.links.menu.yml
@@ -28,3 +28,9 @@ nidirect_workflow.needs_review:
   description: 'Needs Review'
   parent: nidirect_workflow.my_workbench
   weight: 3
+nidirect_workflow.needs_audit:
+  title: 'Needs Audit'
+  route_name: view.workflow_moderation.page_4
+  description: 'Needs Audit'
+  parent: nidirect_workflow.my_workbench
+  weight: 4

--- a/nidirect_workflow/nidirect_workflow.links.menu.yml
+++ b/nidirect_workflow/nidirect_workflow.links.menu.yml
@@ -38,6 +38,6 @@ nidirect_workflow.audit_settings_form:
   title: 'NIDirect Audit Settings Form'
   route_name: nidirect_workflow.audit_settings_form
   description: 'Configure audit settings and messages'
-  parent: system.admin_config_system
+  parent: nidirect.admin_config
   weight: 99
 

--- a/nidirect_workflow/nidirect_workflow.module
+++ b/nidirect_workflow/nidirect_workflow.module
@@ -55,7 +55,7 @@ function nidirect_workflow_entity_presave(EntityInterface $entity) {
  */
 function nidirect_workflow_form_alter(&$form, FormStateInterface $form_state, $form_id) {
 
-  // Disable the 'next audit date' for all but admins.
+  // Manage access to 'next audit date' field.
   if (($form_id == 'node_article_form')
     || ($form_id == 'node_article_edit_form')
     || ($form_id == 'node_contact_form')
@@ -66,8 +66,21 @@ function nidirect_workflow_form_alter(&$form, FormStateInterface $form_state, $f
     || ($form_id == 'node_health_condition_edit_form')
   ) {
     $account = User::load(\Drupal::currentUser()->id());
-    if (!$account->hasRole('administrator')) {
-      $form['field_next_audit_due']['#disabled'] = 'TRUE';
+    // Check user access level.
+    if ($account->hasRole('administrator')) {
+      // Admin can see audit date and change it.
+      $form['field_next_audit_due']['#access'] = TRUE;
+      $form['field_next_audit_due']['#disabled'] = FALSE;
+    }
+    elseif ($account->hasPermission('audit content')) {
+      // If user has permission to audit content but is not an admin
+      // then they can see the audit date but not change it.
+      $form['field_next_audit_due']['#access'] = TRUE;
+      $form['field_next_audit_due']['#disabled'] = TRUE;
+    }
+    else {
+      // Hide the audit date for anyone else.
+      $form['field_next_audit_due']['#access'] = FALSE;
     }
   }
 }

--- a/nidirect_workflow/nidirect_workflow.module
+++ b/nidirect_workflow/nidirect_workflow.module
@@ -1,7 +1,13 @@
 <?php
 
-use Drupal\Component\Utility\Xss;
+/**
+ * @file
+ * Contains code that provides user dashboard.
+ */
+
+use Drupal\user\Entity\User;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Implements hook_page_attachments().
@@ -26,7 +32,7 @@ function nidirect_workflow_entity_presave(EntityInterface $entity) {
           $next_audit_date = $entity->get('field_next_audit_due')->value;
           if (empty($next_audit_date)) {
             // No audit date set, set it for six months time.
-            $entity->set('field_next_audit_due',date('Y-m-d', strtotime("+6 months")));
+            $entity->set('field_next_audit_due', date('Y-m-d', strtotime("+6 months")));
           }
         }
         // - Need to add the 'audit this content' link to the node view page
@@ -46,3 +52,16 @@ function nidirect_workflow_entity_presave(EntityInterface $entity) {
   }
 }
 
+/**
+ * Implements hook_form_alter().
+ */
+function nidirect_workflow_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+
+  // Disable the 'next audit date' for all but admins.
+  if (($form_id == 'node_article_form') || ($form_id == 'node_article_edit_form')) {
+    $account = User::load(\Drupal::currentUser()->id());
+    if (!$account->hasRole('administrator')) {
+      $form['field_next_audit_due']['#disabled'] = 'TRUE';
+    }
+  }
+}

--- a/nidirect_workflow/nidirect_workflow.module
+++ b/nidirect_workflow/nidirect_workflow.module
@@ -35,8 +35,6 @@ function nidirect_workflow_entity_presave(EntityInterface $entity) {
             $entity->set('field_next_audit_due', date('Y-m-d', strtotime("+6 months")));
           }
         }
-        // - Need to add the 'audit this content' link to the node view page
-        // - Need to restrict access to the field in node edit.
         break;
 
       case 'health_condition':
@@ -45,7 +43,7 @@ function nidirect_workflow_entity_presave(EntityInterface $entity) {
           $review_date = $entity->get('field_next_review_date')->value;
           if (!empty($review_date)) {
             // Set 'audit due' date to be the same.
-            $next_audit_date = $entity->get('field_next_audit_due')->value;
+            $entity->set('field_next_audit_due', $review_date);
           }
         }
     }
@@ -58,7 +56,15 @@ function nidirect_workflow_entity_presave(EntityInterface $entity) {
 function nidirect_workflow_form_alter(&$form, FormStateInterface $form_state, $form_id) {
 
   // Disable the 'next audit date' for all but admins.
-  if (($form_id == 'node_article_form') || ($form_id == 'node_article_edit_form')) {
+  if (($form_id == 'node_article_form')
+    || ($form_id == 'node_article_edit_form')
+    || ($form_id == 'node_contact_form')
+    || ($form_id == 'node_contact_edit_form')
+    || ($form_id == 'node_page_form')
+    || ($form_id == 'node_page_edit_form')
+    || ($form_id == 'node_health_condition_form')
+    || ($form_id == 'node_health_condition_edit_form')
+  ) {
     $account = User::load(\Drupal::currentUser()->id());
     if (!$account->hasRole('administrator')) {
       $form['field_next_audit_due']['#disabled'] = 'TRUE';

--- a/nidirect_workflow/nidirect_workflow.module
+++ b/nidirect_workflow/nidirect_workflow.module
@@ -36,16 +36,6 @@ function nidirect_workflow_entity_presave(EntityInterface $entity) {
           }
         }
         break;
-
-      case 'health_condition':
-        if ($entity->isPublished()) {
-          // Has a 'next review' date been set ?
-          $review_date = $entity->get('field_next_review_date')->value;
-          if (!empty($review_date)) {
-            // Set 'audit due' date to be the same.
-            $entity->set('field_next_audit_due', $review_date);
-          }
-        }
     }
   }
 }
@@ -62,8 +52,6 @@ function nidirect_workflow_form_alter(&$form, FormStateInterface $form_state, $f
     || ($form_id == 'node_contact_edit_form')
     || ($form_id == 'node_page_form')
     || ($form_id == 'node_page_edit_form')
-    || ($form_id == 'node_health_condition_form')
-    || ($form_id == 'node_health_condition_edit_form')
   ) {
     $account = User::load(\Drupal::currentUser()->id());
     // Check user access level.

--- a/nidirect_workflow/nidirect_workflow.module
+++ b/nidirect_workflow/nidirect_workflow.module
@@ -1,5 +1,8 @@
 <?php
 
+use Drupal\Component\Utility\Xss;
+use Drupal\Core\Entity\EntityInterface;
+
 /**
  * Implements hook_page_attachments().
  */
@@ -7,3 +10,39 @@ function nidirect_workflow_page_attachments(array &$attachments) {
   // Attach extra custom css for admin menu.
   $attachments['#attached']['library'][] = 'nidirect_workflow/admin.css';
 }
+
+/**
+ * Implements hook_entity_presave().
+ */
+function nidirect_workflow_entity_presave(EntityInterface $entity) {
+  // This will fire when nodes are created or edited.
+  if ($entity->getEntityTypeId() == 'node') {
+    switch ($entity->bundle()) {
+      case 'article':
+      case 'contact':
+      case 'page':
+        // We have just published a node type that is subject to auditing.
+        if ($entity->isPublished()) {
+          $next_audit_date = $entity->get('field_next_audit_due')->value;
+          if (empty($next_audit_date)) {
+            // No audit date set, set it for six months time.
+            $entity->set('field_next_audit_due',date('Y-m-d', strtotime("+6 months")));
+          }
+        }
+        // - Need to add the 'audit this content' link to the node view page
+        // - Need to restrict access to the field in node edit.
+        break;
+
+      case 'health_condition':
+        if ($entity->isPublished()) {
+          // Has a 'next review' date been set ?
+          $review_date = $entity->get('field_next_review_date')->value;
+          if (!empty($review_date)) {
+            // Set 'audit due' date to be the same.
+            $next_audit_date = $entity->get('field_next_audit_due')->value;
+          }
+        }
+    }
+  }
+}
+

--- a/nidirect_workflow/nidirect_workflow.permissions.yml
+++ b/nidirect_workflow/nidirect_workflow.permissions.yml
@@ -1,0 +1,3 @@
+audit content:
+  title: 'Audit Content'
+  description: 'A custom permission that allows an editor to audit content'

--- a/nidirect_workflow/nidirect_workflow.routing.yml
+++ b/nidirect_workflow/nidirect_workflow.routing.yml
@@ -22,3 +22,14 @@ nidirect_workflow.audit_controller_confirm_audit:
     _title: 'Confirm Audit'
   requirements:
     _permission: 'access content'
+
+nidirect_workflow.audit_settings_form:
+  path: '/admin/config/nidirect_workflow/auditsettings'
+  defaults:
+    _form: '\Drupal\nidirect_workflow\Form\AuditSettingsForm'
+    _title: 'NIDirect Audit Settings Form'
+  requirements:
+    _permission: 'access administration pages'
+  options:
+    _admin_route: TRUE
+

--- a/nidirect_workflow/nidirect_workflow.routing.yml
+++ b/nidirect_workflow/nidirect_workflow.routing.yml
@@ -6,3 +6,11 @@ nidirect_workflow.moderation_state_controller_change_state:
     _title: 'change_state'
   requirements:
     _permission: 'access content'
+
+nidirect_workflow.audit_controller_content_audit:
+  path: '/nidirect_workflow/content_audit'
+  defaults:
+    _controller: '\Drupal\nidirect_workflow\Controller\AuditController::contentAudit'
+    _title: 'content_audit'
+  requirements:
+    _permission: 'access content'

--- a/nidirect_workflow/nidirect_workflow.routing.yml
+++ b/nidirect_workflow/nidirect_workflow.routing.yml
@@ -13,7 +13,7 @@ nidirect_workflow.audit_controller_content_audit:
     _controller: '\Drupal\nidirect_workflow\Controller\AuditController::contentAudit'
     _title: 'Content Audit'
   requirements:
-    _permission: 'access content'
+    _permission: 'audit content'
 
 nidirect_workflow.audit_controller_confirm_audit:
   path: '/nidirect_workflow/confirm_audit/{nid}'
@@ -21,7 +21,7 @@ nidirect_workflow.audit_controller_confirm_audit:
     _controller: '\Drupal\nidirect_workflow\Controller\AuditController::confirmAudit'
     _title: 'Confirm Audit'
   requirements:
-    _permission: 'access content'
+    _permission: 'audit content'
 
 nidirect_workflow.audit_settings_form:
   path: '/admin/config/nidirect_workflow/auditsettings'

--- a/nidirect_workflow/nidirect_workflow.routing.yml
+++ b/nidirect_workflow/nidirect_workflow.routing.yml
@@ -8,7 +8,7 @@ nidirect_workflow.moderation_state_controller_change_state:
     _permission: 'access content'
 
 nidirect_workflow.audit_controller_content_audit:
-  path: '/nidirect_workflow/content_audit'
+  path: '/nidirect_workflow/content_audit/{nid}'
   defaults:
     _controller: '\Drupal\nidirect_workflow\Controller\AuditController::contentAudit'
     _title: 'content_audit'

--- a/nidirect_workflow/nidirect_workflow.routing.yml
+++ b/nidirect_workflow/nidirect_workflow.routing.yml
@@ -11,6 +11,14 @@ nidirect_workflow.audit_controller_content_audit:
   path: '/nidirect_workflow/content_audit/{nid}'
   defaults:
     _controller: '\Drupal\nidirect_workflow\Controller\AuditController::contentAudit'
-    _title: 'content_audit'
+    _title: 'Content Audit'
+  requirements:
+    _permission: 'access content'
+
+nidirect_workflow.audit_controller_confirm_audit:
+  path: '/nidirect_workflow/confirm_audit/{nid}'
+  defaults:
+    _controller: '\Drupal\nidirect_workflow\Controller\AuditController::confirmAudit'
+    _title: 'Confirm Audit'
   requirements:
     _permission: 'access content'

--- a/nidirect_workflow/src/Controller/AuditController.php
+++ b/nidirect_workflow/src/Controller/AuditController.php
@@ -17,17 +17,35 @@ class AuditController extends ControllerBase {
    */
   public function contentAudit($nid) {
     $msg = 'Invalid node id';
+    // Don't forget translations.
+    // Don't forget dependency injection.
     if (!empty($nid)) {
       $node = \Drupal\node\Entity\Node::load($nid);
       if ($node) {
         $msg = "Click this button to indicate that you have audited this published content ";
         $msg .= "and are happy that it is still accurate and relevant.";
-        $msg .= "<div><a href='/nidirect_workflow/audit_confirm/$nid'>Audit this published content</a></div>";
+        $msg .= "<div><a href='/nidirect_workflow/confirm_audit/$nid'>Audit this published content</a></div>";
       }
     }
     return [
       '#type' => 'markup',
       '#markup' => $this->t($msg)
+    ];
+  }
+
+  /**
+   * Confirm Audit.
+   *
+   * @return string
+   *   Return confirmation string.
+   */
+  public function confirmAudit($nid) {
+    $msg = 'Invalid node id';
+    // Don't display anything, just do the update and
+    // follow the 'destination' param.
+    return [
+      '#type' => 'markup',
+      '#markup' => $this->t('Successfully audited')
     ];
   }
 

--- a/nidirect_workflow/src/Controller/AuditController.php
+++ b/nidirect_workflow/src/Controller/AuditController.php
@@ -79,7 +79,7 @@ class AuditController extends ControllerBase implements ContainerInjectionInterf
       $node = $this->entityTypeManager()->getStorage('node')->load($nid);
       if ($node) {
         $msg = t("Click this button to indicate that you have audited this published content and are happy that it is still accurate and relevant.");
-        $msg .= "<div><a href='/nidirect_workflow/confirm_audit/$nid'>" . t("Audit this published content") . "</a></div>";
+        $msg .= "<div><a href='/nidirect_workflow/confirm_audit/$nid?destination=/node/$nid'>" . t("Audit this published content") . "</a></div>";
       }
     }
     return [
@@ -104,7 +104,7 @@ class AuditController extends ControllerBase implements ContainerInjectionInterf
       $this->logger->notice($message);
     }
     // Redirect user to node view (although the 'destination'
-    // url argument will override this).
+    // url argument may override this).
     return $this->redirect('entity.node.canonical', ['node' => $nid]);
   }
 

--- a/nidirect_workflow/src/Controller/AuditController.php
+++ b/nidirect_workflow/src/Controller/AuditController.php
@@ -13,12 +13,21 @@ class AuditController extends ControllerBase {
    * Content Audit.
    *
    * @return string
-   *   Return cofirmation string.
+   *   Return confirmation string.
    */
-  public function contentAudit() {
+  public function contentAudit($nid) {
+    $msg = 'Invalid node id';
+    if (!empty($nid)) {
+      $node = \Drupal\node\Entity\Node::load($nid);
+      if ($node) {
+        $msg = "Click this button to indicate that you have audited this published content ";
+        $msg .= "and are happy that it is still accurate and relevant.";
+        $msg .= "<div><a href='/nidirect_workflow/audit_confirm/$nid'>Audit this published content</a></div>";
+      }
+    }
     return [
       '#type' => 'markup',
-      '#markup' => $this->t('Do you want to audit ?')
+      '#markup' => $this->t($msg)
     ];
   }
 

--- a/nidirect_workflow/src/Controller/AuditController.php
+++ b/nidirect_workflow/src/Controller/AuditController.php
@@ -70,7 +70,6 @@ class AuditController extends ControllerBase implements ContainerInjectionInterf
    */
   public function contentAudit($nid) {
     $msg = 'Invalid node id';
-    // Don't forget translations.
     if (!empty($nid)) {
       $node = $this->entityTypeManager()->getStorage('node')->load($nid);
       if ($node) {

--- a/nidirect_workflow/src/Controller/AuditController.php
+++ b/nidirect_workflow/src/Controller/AuditController.php
@@ -74,8 +74,10 @@ class AuditController extends ControllerBase implements ContainerInjectionInterf
     if (!empty($nid)) {
       $node = $this->entityTypeManager()->getStorage('node')->load($nid);
       if ($node) {
-        $msg = $this->t("Click this button to indicate that you have audited this published content and are happy that it is still accurate and relevant.");
-        $msg .= "<div><a href='/nidirect_workflow/confirm_audit/$nid?destination=/node/$nid'>" . $this->t("Audit this published content") . "</a></div>";
+        $audit_button_text = $this->config('nidirect_workflow.auditsettings')->get('audit_button_text');
+        $audit_confirmation_text = $this->config('nidirect_workflow.auditsettings')->get('audit_confirmation_text');
+        $msg = $this->t($audit_confirmation_text);
+        $msg .= "<div><a href='/nidirect_workflow/confirm_audit/$nid?destination=/node/$nid'>" . $this->t($audit_button_text) . "</a></div>";
         $msg .= "<div><a href='/node/$nid'>" . $this->t("Cancel") . "</a></div>";
       }
     }

--- a/nidirect_workflow/src/Controller/AuditController.php
+++ b/nidirect_workflow/src/Controller/AuditController.php
@@ -4,6 +4,8 @@ namespace Drupal\nidirect_workflow\Controller;
 
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
 use Drupal\Core\Controller\ControllerBase;
 use Psr\Log\LoggerInterface;
@@ -29,16 +31,26 @@ class AuditController extends ControllerBase implements ContainerInjectionInterf
   protected $logger;
 
   /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $account;
+
+  /**
    * Creates a new ModerationStateConstraintValidator instance.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager.
    * @param \Psr\Log\LoggerInterface $logger
    *   The logger interface.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The current user.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, LoggerInterface $logger) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, LoggerInterface $logger, AccountInterface $account) {
     $this->entityTypeManager = $entity_type_manager;
     $this->logger = $logger;
+    $this->account = $account;
   }
 
   /**
@@ -47,7 +59,8 @@ class AuditController extends ControllerBase implements ContainerInjectionInterf
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('entity_type.manager'),
-      $container->get('logger.factory')->get('nidirect_workflow')
+      $container->get('logger.factory')->get('nidirect_workflow'),
+      $container->get('current_user')
     );
   }
 
@@ -63,12 +76,10 @@ class AuditController extends ControllerBase implements ContainerInjectionInterf
     $msg = 'Invalid node id';
     // Don't forget translations.
     if (!empty($nid)) {
-      //$node = Node::load($nid);
       $node = $this->entityTypeManager()->getStorage('node')->load($nid);
       if ($node) {
-        $msg = "Click this button to indicate that you have audited this published content ";
-        $msg .= "and are happy that it is still accurate and relevant.";
-        $msg .= "<div><a href='/nidirect_workflow/confirm_audit/$nid'>Audit this published content</a></div>";
+        $msg = t("Click this button to indicate that you have audited this published content and are happy that it is still accurate and relevant.");
+        $msg .= "<div><a href='/nidirect_workflow/confirm_audit/$nid'>" . t("Audit this published content") . "</a></div>";
       }
     }
     return [
@@ -84,13 +95,17 @@ class AuditController extends ControllerBase implements ContainerInjectionInterf
    *   Return confirmation string.
    */
   public function confirmAudit($nid) {
-    $msg = 'Invalid node id';
-    // Don't display anything, just do the update and
-    // follow the 'destination' param.
-    return [
-      '#type' => 'markup',
-      '#markup' => $this->t('Successfully audited'),
-    ];
+    // Bump up the 'next audit due' date and log it.
+    $node = $this->entityTypeManager()->getStorage('node')->load($nid);
+    if ($node) {
+      $node->set('field_next_audit_due',date('Y-m-d', strtotime("+6 months")));
+      $node->save();
+      $message = "nid " . $nid . " has been audited by " . $this->account->getAccountName() . " (uid " . $this->account->id() . ")";
+      $this->logger->notice($message);
+    }
+    // Redirect user to node view (although the 'destination'
+    // url argument will override this).
+    return $this->redirect('entity.node.canonical', ['node' => $nid]);
   }
 
 }

--- a/nidirect_workflow/src/Controller/AuditController.php
+++ b/nidirect_workflow/src/Controller/AuditController.php
@@ -2,12 +2,56 @@
 
 namespace Drupal\nidirect_workflow\Controller;
 
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\node\Entity\Node;
 use Drupal\Core\Controller\ControllerBase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Class AuditController.
  */
-class AuditController extends ControllerBase {
+class AuditController extends ControllerBase implements ContainerInjectionInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * A logger instance.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
+   * Creates a new ModerationStateConstraintValidator instance.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The logger interface.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, LoggerInterface $logger) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('logger.factory')->get('nidirect_workflow')
+    );
+  }
+
+  /**
 
   /**
    * Content Audit.
@@ -18,9 +62,9 @@ class AuditController extends ControllerBase {
   public function contentAudit($nid) {
     $msg = 'Invalid node id';
     // Don't forget translations.
-    // Don't forget dependency injection.
     if (!empty($nid)) {
-      $node = \Drupal\node\Entity\Node::load($nid);
+      //$node = Node::load($nid);
+      $node = $this->entityTypeManager()->getStorage('node')->load($nid);
       if ($node) {
         $msg = "Click this button to indicate that you have audited this published content ";
         $msg .= "and are happy that it is still accurate and relevant.";
@@ -29,7 +73,7 @@ class AuditController extends ControllerBase {
     }
     return [
       '#type' => 'markup',
-      '#markup' => $this->t($msg)
+      '#markup' => $this->t($msg),
     ];
   }
 
@@ -45,7 +89,7 @@ class AuditController extends ControllerBase {
     // follow the 'destination' param.
     return [
       '#type' => 'markup',
-      '#markup' => $this->t('Successfully audited')
+      '#markup' => $this->t('Successfully audited'),
     ];
   }
 

--- a/nidirect_workflow/src/Controller/AuditController.php
+++ b/nidirect_workflow/src/Controller/AuditController.php
@@ -76,6 +76,7 @@ class AuditController extends ControllerBase implements ContainerInjectionInterf
       if ($node) {
         $msg = $this->t("Click this button to indicate that you have audited this published content and are happy that it is still accurate and relevant.");
         $msg .= "<div><a href='/nidirect_workflow/confirm_audit/$nid?destination=/node/$nid'>" . $this->t("Audit this published content") . "</a></div>";
+        $msg .= "<div><a href='/node/$nid'>" . $this->t("Cancel") . "</a></div>";
       }
     }
     return [

--- a/nidirect_workflow/src/Controller/AuditController.php
+++ b/nidirect_workflow/src/Controller/AuditController.php
@@ -5,8 +5,6 @@ namespace Drupal\nidirect_workflow\Controller;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\Url;
-use Drupal\node\Entity\Node;
 use Drupal\Core\Controller\ControllerBase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -65,8 +63,6 @@ class AuditController extends ControllerBase implements ContainerInjectionInterf
   }
 
   /**
-
-  /**
    * Content Audit.
    *
    * @return string
@@ -78,13 +74,13 @@ class AuditController extends ControllerBase implements ContainerInjectionInterf
     if (!empty($nid)) {
       $node = $this->entityTypeManager()->getStorage('node')->load($nid);
       if ($node) {
-        $msg = t("Click this button to indicate that you have audited this published content and are happy that it is still accurate and relevant.");
-        $msg .= "<div><a href='/nidirect_workflow/confirm_audit/$nid?destination=/node/$nid'>" . t("Audit this published content") . "</a></div>";
+        $msg = $this->t("Click this button to indicate that you have audited this published content and are happy that it is still accurate and relevant.");
+        $msg .= "<div><a href='/nidirect_workflow/confirm_audit/$nid?destination=/node/$nid'>" . $this->t("Audit this published content") . "</a></div>";
       }
     }
     return [
       '#type' => 'markup',
-      '#markup' => $this->t($msg),
+      '#markup' => $msg,
     ];
   }
 
@@ -98,9 +94,10 @@ class AuditController extends ControllerBase implements ContainerInjectionInterf
     // Bump up the 'next audit due' date and log it.
     $node = $this->entityTypeManager()->getStorage('node')->load($nid);
     if ($node) {
-      $node->set('field_next_audit_due',date('Y-m-d', strtotime("+6 months")));
+      $node->set('field_next_audit_due', date('Y-m-d', strtotime("+6 months")));
       $node->save();
-      $message = "nid " . $nid . " has been audited by " . $this->account->getAccountName() . " (uid " . $this->account->id() . ")";
+      $message = "nid " . $nid . " " . $this->t("has been audited by") . " ";
+      $message .= $this->account->getAccountName() . " (uid " . $this->account->id() . ")";
       $this->logger->notice($message);
     }
     // Redirect user to node view (although the 'destination'

--- a/nidirect_workflow/src/Controller/AuditController.php
+++ b/nidirect_workflow/src/Controller/AuditController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\nidirect_workflow\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+
+/**
+ * Class AuditController.
+ */
+class AuditController extends ControllerBase {
+
+  /**
+   * Content Audit.
+   *
+   * @return string
+   *   Return cofirmation string.
+   */
+  public function contentAudit() {
+    return [
+      '#type' => 'markup',
+      '#markup' => $this->t('Do you want to audit ?')
+    ];
+  }
+
+}

--- a/nidirect_workflow/src/Form/AuditSettingsForm.php
+++ b/nidirect_workflow/src/Form/AuditSettingsForm.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\nidirect_workflow\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Class AuditSettingsForm.
+ */
+class AuditSettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'nidirect_workflow.auditsettings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'audit_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('nidirect_workflow.auditsettings');
+
+    $form['audit_button_text'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Audit button text'),
+      '#description' => $this->t('Text to be displayed on the button that the editor presses to audit the content.'),
+      '#default_value' => $config->get('audit_button_text'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    parent::validateForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+
+    $this->config('nidirect_workflow.auditsettings')
+      ->set('audit_button_text', $form_state->getValue('audit_button_text'))
+      ->save();
+  }
+
+}

--- a/nidirect_workflow/src/Form/AuditSettingsForm.php
+++ b/nidirect_workflow/src/Form/AuditSettingsForm.php
@@ -61,13 +61,6 @@ class AuditSettingsForm extends ConfigFormBase {
   /**
    * {@inheritdoc}
    */
-  public function validateForm(array &$form, FormStateInterface $form_state) {
-    parent::validateForm($form, $form_state);
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     parent::submitForm($form, $form_state);
 

--- a/nidirect_workflow/src/Form/AuditSettingsForm.php
+++ b/nidirect_workflow/src/Form/AuditSettingsForm.php
@@ -39,6 +39,22 @@ class AuditSettingsForm extends ConfigFormBase {
       '#default_value' => $config->get('audit_button_text'),
     ];
 
+    $form['audit_button_hover_text'] = [
+      '#type' => 'textfield',
+      '#size' => 130,
+      '#title' => $this->t('Audit button hover text'),
+      '#description' => $this->t('Text to be displayed when the editor hovers their mouse over the audit button.'),
+      '#default_value' => $config->get('audit_button_hover_text'),
+    ];
+
+    $form['audit_confirmation_text'] = [
+      '#type' => 'textfield',
+      '#size' => 130,
+      '#title' => $this->t('Audit confirmation text'),
+      '#description' => $this->t('Ask the editor to confirm that they have audited the content.'),
+      '#default_value' => $config->get('audit_confirmation_text'),
+    ];
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -57,6 +73,8 @@ class AuditSettingsForm extends ConfigFormBase {
 
     $this->config('nidirect_workflow.auditsettings')
       ->set('audit_button_text', $form_state->getValue('audit_button_text'))
+      ->set('audit_button_hover_text', $form_state->getValue('audit_button_hover_text'))
+      ->set('audit_confirmation_text', $form_state->getValue('audit_confirmation_text'))
       ->save();
   }
 


### PR DESCRIPTION
- Add 'needs audit' view to dashboard
- Implement audit functionality driven by dates to replace old implementation that used Flags, Rules and Rules Scheduler. 
- Implemented a custom 'audit content' permission which controls access to auditing
- Implement NIDirect admin screen under 'Configuration' that allows audit strings to be maintained