### PR TITLE
Add a search breadcrumb handler class

### DIFF
--- a/nidirect_breadcrumbs/nidirect_breadcrumbs.services.yml
+++ b/nidirect_breadcrumbs/nidirect_breadcrumbs.services.yml
@@ -27,3 +27,7 @@ services:
     class: Drupal\nidirect_breadcrumbs\RecipeBreadcrumb
     tags:
       - { name: breadcrumb_builder }
+  nidirect_breadcrumbs.breadcrumb.search:
+    class: Drupal\nidirect_breadcrumbs\SearchBreadcrumb
+    tags:
+      - { name: breadcrumb_builder }

--- a/nidirect_breadcrumbs/nidirect_breadcrumbs.services.yml
+++ b/nidirect_breadcrumbs/nidirect_breadcrumbs.services.yml
@@ -29,5 +29,10 @@ services:
       - { name: breadcrumb_builder }
   nidirect_breadcrumbs.breadcrumb.search:
     class: Drupal\nidirect_breadcrumbs\SearchBreadcrumb
+    arguments: ['%breadcrumb.search.matches%']
     tags:
       - { name: breadcrumb_builder }
+
+parameters:
+  breadcrumb.search.matches:
+    - view.search.page_1

--- a/nidirect_breadcrumbs/src/SearchBreadcrumb.php
+++ b/nidirect_breadcrumbs/src/SearchBreadcrumb.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\nidirect_breadcrumbs;
+
+/**
+ * @file
+ * Generates the breadcrumb trail for search page(s)
+ */
+
+use Drupal\Core\Breadcrumb\Breadcrumb;
+use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Url;
+
+class SearchBreadcrumb implements BreadcrumbBuilderInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies(RouteMatchInterface $route_match) {
+    $match = FALSE;
+
+    if ($route_match->getRouteName() == 'view.search.page_1') {
+      $match = TRUE;
+    }
+
+    return $match;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(RouteMatchInterface $route_match) {
+
+    $breadcrumb = new Breadcrumb();
+    $breadcrumb->setLinks([]);
+    $breadcrumb->addCacheContexts(['url.path']);
+
+    return $breadcrumb;
+  }
+
+}

--- a/nidirect_breadcrumbs/src/SearchBreadcrumb.php
+++ b/nidirect_breadcrumbs/src/SearchBreadcrumb.php
@@ -12,8 +12,25 @@ use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class SearchBreadcrumb implements BreadcrumbBuilderInterface {
+
+  /**
+   * Class constructor.
+   */
+  public function __construct(array $route_matches) {
+    $this->routeMatches = $route_matches;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('breadcrumb.search.matches')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -21,7 +38,7 @@ class SearchBreadcrumb implements BreadcrumbBuilderInterface {
   public function applies(RouteMatchInterface $route_match) {
     $match = FALSE;
 
-    if ($route_match->getRouteName() == 'view.search.page_1') {
+    if (in_array($route_match->getRouteName(), $this->routeMatches)) {
       $match = TRUE;
     }
 


### PR DESCRIPTION
Search results pages do not show a breadcrumb. Rather than preprocess the heck out the template for that page (as per D7) we can introduce a new breadcrumb handler class that responds to the route name and can, in this case, set an empty array of links which in turn means nothing is rendered.

In future, if we need to adjust other views displays - we only need to put some more conditional checks on the route and can adapt what is displayed in each instance.