### PR TITLE
Inject entity type manager to obtain full node object when required

### DIFF
--- a/nidirect_breadcrumbs/nidirect_breadcrumbs.services.yml
+++ b/nidirect_breadcrumbs/nidirect_breadcrumbs.services.yml
@@ -1,29 +1,36 @@
 services:
   nidirect_breadcrumbs.breadcrumb.themes:
     class: Drupal\nidirect_breadcrumbs\ThemesBreadcrumb
+    arguments: ['@entity_type.manager']
     tags:
       - { name: breadcrumb_builder }
   nidirect_breadcrumbs.breadcrumb.umbrella_bodies:
     class: Drupal\nidirect_breadcrumbs\UmbrellaBodyBreadcrumb
+    arguments: ['@entity_type.manager']
     tags:
       - { name: breadcrumb_builder }
   nidirect_breadcrumbs.breadcrumb.contact:
     class: Drupal\nidirect_breadcrumbs\ContactBreadcrumb
+    arguments: ['@entity_type.manager']
     tags:
       - { name: breadcrumb_builder }
   nidirect_breadcrumbs.breadcrumb.gp_practice:
     class: Drupal\nidirect_breadcrumbs\GpPracticeBreadcrumb
+    arguments: ['@entity_type.manager']
     tags:
       - { name: breadcrumb_builder }
   nidirect_breadcrumbs.breadcrumb.health_condition:
     class: Drupal\nidirect_breadcrumbs\HealthConditionBreadcrumb
+    arguments: ['@entity_type.manager']
     tags:
       - { name: breadcrumb_builder }
   nidirect_breadcrumbs.breadcrumb.news:
     class: Drupal\nidirect_breadcrumbs\NewsBreadcrumb
+    arguments: ['@entity_type.manager']
     tags:
       - { name: breadcrumb_builder }
   nidirect_breadcrumbs.breadcrumb.recipe:
     class: Drupal\nidirect_breadcrumbs\RecipeBreadcrumb
+    arguments: ['@entity_type.manager']
     tags:
       - { name: breadcrumb_builder }

--- a/nidirect_breadcrumbs/src/ContactBreadcrumb.php
+++ b/nidirect_breadcrumbs/src/ContactBreadcrumb.php
@@ -17,11 +17,31 @@ namespace Drupal\nidirect_breadcrumbs;
 
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class ContactBreadcrumb implements BreadcrumbBuilderInterface {
+
+  protected $entityTypeManager;
+
+  /**
+   * Class constructor.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -30,6 +50,10 @@ class ContactBreadcrumb implements BreadcrumbBuilderInterface {
     $match = FALSE;
 
     if ($node = $route_match->getParameter('node')) {
+      if (is_object($node) == FALSE) {
+        $node = $this->entityTypeManager->getStorage('node')->load($node);
+      }
+      $bundle = $node->bundle();
       $match = $node->bundle() == 'contact';
     }
 

--- a/nidirect_breadcrumbs/src/GpPracticeBreadcrumb.php
+++ b/nidirect_breadcrumbs/src/GpPracticeBreadcrumb.php
@@ -23,11 +23,31 @@ namespace Drupal\nidirect_breadcrumbs;
 
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class GpPracticeBreadcrumb implements BreadcrumbBuilderInterface {
+
+  protected $entityTypeManager;
+
+  /**
+   * Class constructor.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -36,6 +56,10 @@ class GpPracticeBreadcrumb implements BreadcrumbBuilderInterface {
     $match = FALSE;
 
     if ($node = $route_match->getParameter('node')) {
+      if (is_object($node) == FALSE) {
+        $node = $this->entityTypeManager->getStorage('node')->load($node);
+      }
+      $bundle = $node->bundle();
       $match = $node->bundle() == 'gp_practice';
     }
 

--- a/nidirect_breadcrumbs/src/HealthConditionBreadcrumb.php
+++ b/nidirect_breadcrumbs/src/HealthConditionBreadcrumb.php
@@ -21,11 +21,31 @@ namespace Drupal\nidirect_breadcrumbs;
 
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class HealthConditionBreadcrumb implements BreadcrumbBuilderInterface {
+
+  protected $entityTypeManager;
+
+  /**
+   * Class constructor.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -34,6 +54,10 @@ class HealthConditionBreadcrumb implements BreadcrumbBuilderInterface {
     $match = FALSE;
 
     if ($node = $route_match->getParameter('node')) {
+      if (is_object($node) == FALSE) {
+        $node = $this->entityTypeManager->getStorage('node')->load($node);
+      }
+      $bundle = $node->bundle();
       $match = $node->bundle() == 'health_condition';
     }
 

--- a/nidirect_breadcrumbs/src/NewsBreadcrumb.php
+++ b/nidirect_breadcrumbs/src/NewsBreadcrumb.php
@@ -17,11 +17,31 @@ namespace Drupal\nidirect_breadcrumbs;
 
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class NewsBreadcrumb implements BreadcrumbBuilderInterface {
+
+  protected $entityTypeManager;
+
+  /**
+   * Class constructor.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -30,6 +50,10 @@ class NewsBreadcrumb implements BreadcrumbBuilderInterface {
     $match = FALSE;
 
     if ($node = $route_match->getParameter('node')) {
+      if (is_object($node) == FALSE) {
+        $node = $this->entityTypeManager->getStorage('node')->load($node);
+      }
+      $bundle = $node->bundle();
       $match = $node->bundle() == 'news';
     }
 

--- a/nidirect_breadcrumbs/src/RecipeBreadcrumb.php
+++ b/nidirect_breadcrumbs/src/RecipeBreadcrumb.php
@@ -21,11 +21,31 @@ namespace Drupal\nidirect_breadcrumbs;
 
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class RecipeBreadcrumb implements BreadcrumbBuilderInterface {
+
+  protected $entityTypeManager;
+
+  /**
+   * Class constructor.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -34,6 +54,10 @@ class RecipeBreadcrumb implements BreadcrumbBuilderInterface {
     $match = FALSE;
 
     if ($node = $route_match->getParameter('node')) {
+      if (is_object($node) == FALSE) {
+        $node = $this->entityTypeManager->getStorage('node')->load($node);
+      }
+      $bundle = $node->bundle();
       $match = $node->bundle() == 'recipe';
     }
 

--- a/nidirect_breadcrumbs/src/ThemesBreadcrumb.php
+++ b/nidirect_breadcrumbs/src/ThemesBreadcrumb.php
@@ -16,11 +16,31 @@ namespace Drupal\nidirect_breadcrumbs;
 
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class ThemesBreadcrumb implements BreadcrumbBuilderInterface {
+
+  protected $entityTypeManager;
+
+  /**
+   * Class constructor.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -35,7 +55,12 @@ class ThemesBreadcrumb implements BreadcrumbBuilderInterface {
     ];
 
     if ($node = $route_match->getParameter('node')) {
-      $match = in_array($node->bundle(), $applies_to_types);
+      if (is_object($node) == FALSE) {
+        $node = $this->entityTypeManager->getStorage('node')->load($node);
+      }
+      $bundle = $node->bundle();
+
+      $match = in_array($bundle, $applies_to_types);
     }
 
     return $match;

--- a/nidirect_breadcrumbs/src/UmbrellaBodyBreadcrumb.php
+++ b/nidirect_breadcrumbs/src/UmbrellaBodyBreadcrumb.php
@@ -21,11 +21,31 @@ namespace Drupal\nidirect_breadcrumbs;
 
 use Drupal\Core\Breadcrumb\Breadcrumb;
 use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class UmbrellaBodyBreadcrumb implements BreadcrumbBuilderInterface {
+
+  protected $entityTypeManager;
+
+  /**
+   * Class constructor.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -34,6 +54,10 @@ class UmbrellaBodyBreadcrumb implements BreadcrumbBuilderInterface {
     $match = FALSE;
 
     if ($node = $route_match->getParameter('node')) {
+      if (is_object($node) == FALSE) {
+        $node = $this->entityTypeManager->getStorage('node')->load($node);
+      }
+      $bundle = $node->bundle();
       $match = $node->bundle() == 'umbrella_body';
     }
 


### PR DESCRIPTION
Node view page provides the node object, revision listing does not so it
needs to be loaded if the node parameter is not already a fully
instantiated node object