### PR TITLE
D8NID-192 news

### DIFF
--- a/nidirect_news/nidirect_news.info.yml
+++ b/nidirect_news/nidirect_news.info.yml
@@ -1,0 +1,5 @@
+name: 'NIDirect News'
+type: module
+description: 'Custom code to present news content'
+core: 8.x
+package: 'NIDirect'

--- a/nidirect_news/nidirect_news.module
+++ b/nidirect_news/nidirect_news.module
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Contains nidirect_news.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function nidirect_news_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    // Main module help for the nidirect_news module.
+    case 'help.page.nidirect_news':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('Custom code to present news content') . '</p>';
+      return $output;
+
+    default:
+  }
+}

--- a/nidirect_news/nidirect_news.module
+++ b/nidirect_news/nidirect_news.module
@@ -8,17 +8,22 @@
 use Drupal\Core\Routing\RouteMatchInterface;
 
 /**
- * Implements hook_help().
+ * Implements hook_preprocess_field().
  */
-function nidirect_news_help($route_name, RouteMatchInterface $route_match) {
-  switch ($route_name) {
-    // Main module help for the nidirect_news module.
-    case 'help.page.nidirect_news':
-      $output = '';
-      $output .= '<h3>' . t('About') . '</h3>';
-      $output .= '<p>' . t('Custom code to present news content') . '</p>';
-      return $output;
+function nidirect_news_preprocess_field(&$variables) {
+  $entity_type = $variables['entity_type'];
+  $bundle = $variables['element']['#bundle'];
+  $field_name = $variables['field_name'];
+  $view_mode = $variables['element']['#view_mode'];
 
-    default:
+  if ($field_name != 'field_published_date') {
+    return;
   }
+
+  if ($entity_type != 'node' || $bundle != 'news' || $view_mode != 'full') {
+    return;
+  }
+
+  // Adjust the title in full display mode to match present site value.
+  $variables['label'] = t('Date published');
 }

--- a/nidirect_news/nidirect_news.routing.yml
+++ b/nidirect_news/nidirect_news.routing.yml
@@ -1,5 +1,5 @@
 
-nidirect_news.news_listing_controller_hello:
+nidirect_news.news_listing:
   path: '/news'
   defaults:
     _controller: '\Drupal\nidirect_news\Controller\NewsListingController::default'

--- a/nidirect_news/nidirect_news.routing.yml
+++ b/nidirect_news/nidirect_news.routing.yml
@@ -1,0 +1,8 @@
+
+nidirect_news.news_listing_controller_hello:
+  path: '/news'
+  defaults:
+    _controller: '\Drupal\nidirect_news\Controller\NewsListingController::default'
+    _title: 'News'
+  requirements:
+    _permission: 'access content'

--- a/nidirect_news/src/Controller/NewsListingController.php
+++ b/nidirect_news/src/Controller/NewsListingController.php
@@ -73,7 +73,7 @@ class NewsListingController extends ControllerBase {
 
     // Older news.
     $content['older_news'] = [
-      '#type' => 'paragraph',
+      '#type' => 'view',
       '#name' => 'news',
       '#display_id' => 'older_news',
     ];

--- a/nidirect_news/src/Controller/NewsListingController.php
+++ b/nidirect_news/src/Controller/NewsListingController.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Drupal\nidirect_news\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Block\BlockManagerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Class NewsListingController.
+ */
+class NewsListingController extends ControllerBase {
+
+  /**
+   * Drupal\Core\Entity\EntityTypeManagerInterface definition.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+  /**
+   * Drupal\Core\Block\BlockManagerInterface definition.
+   *
+   * @var \Drupal\Core\Block\BlockManagerInterface
+   */
+  protected $pluginManagerBlock;
+  /**
+   * Symfony\Component\HttpFoundation\RequestStack definition.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * Constructs a new NewsListingController object.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, BlockManagerInterface $plugin_manager_block, RequestStack $request_stack) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->pluginManagerBlock = $plugin_manager_block;
+    $this->requestStack = $request_stack;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('plugin.manager.block'),
+      $container->get('request_stack')
+    );
+  }
+
+  /**
+   * Default page listing. Show:
+   *
+   * - Latest news: teaser view per item
+   * - Older news: title + date per item, with full pager.
+   *
+   * @return array
+   *   Render array for the page for Drupal to convert to HTML.
+   */
+  public function default() {
+    $content = [];
+
+    // Latest news embed display.
+    $content['latest_news'] = [
+      '#type' => 'view',
+      '#name' => 'news',
+      '#display_id' => 'latest_news',
+    ];
+
+    // Older news.
+    $content['older_news'] = [
+      '#type' => 'paragraph',
+      '#name' => 'news',
+      '#display_id' => 'older_news',
+    ];
+
+    return $content;
+  }
+
+}


### PR DESCRIPTION
Opted to use two views embed displays managed with a controller for maximum flexibility (ie: if you want to introduce something above/below/between the content lists) that might traditionally be harder on just a views page display. This also mirrors the same approach taken for contacts which had some slightly more bespoke requirements.