### PR TITLE
Add block wrapper around views embed display

### DIFF
--- a/nidirect_common/src/Plugin/Block/SiteSearchBlock.php
+++ b/nidirect_common/src/Plugin/Block/SiteSearchBlock.php
@@ -5,7 +5,14 @@ namespace Drupal\nidirect_common\Plugin\Block;
 use Drupal\Core\Block\BlockBase;
 
 /**
- * Provides a 'SiteSearchBlock' block.
+ * This block acts as a wrapper around a views embed display.
+ * A block display alone requires AJAX on exposed filters which
+ * means the search autocomplete will reload the same page if
+ * no item is selected from the autocomplete list. What we want
+ * it to do is respect the original action attribute on the form
+ * element and ensure if no autocomplete terms are selected and
+ * the form is submitted (eg: with the enter key) then the browser
+ * follows the path defined in the action attribute.
  *
  * @Block(
  *  id = "site_search_block",

--- a/nidirect_common/src/Plugin/Block/SiteSearchBlock.php
+++ b/nidirect_common/src/Plugin/Block/SiteSearchBlock.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Drupal\nidirect_common\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+
+/**
+ * Provides a 'SiteSearchBlock' block.
+ *
+ * @Block(
+ *  id = "site_search_block",
+ *  admin_label = @Translation("Site search block"),
+ * )
+ */
+class SiteSearchBlock extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $build['site_search_block']['site_search'] = [
+      '#type' => 'view',
+      '#name' => 'search',
+      '#display_id' => 'site_search',
+    ];
+
+    return $build;
+  }
+
+}


### PR DESCRIPTION
Necessary to allow exposed filter to work correctly. Normally you can add a views block display and the AJAX filters work for your needs, but because we introduce search_api_autocomplete we want to either move the user on form submit to the URL of the item selected or, if nothing, to the default form action path. AJAX filters don't allow this, so with a small block to wrap the display we can get around this limitation.