### PR TITLE
D8NID-258 Add custom module to mediate access to taxonomy terms

### DIFF
--- a/nidirect_site_themes/nidirect_site_themes.info.yml
+++ b/nidirect_site_themes/nidirect_site_themes.info.yml
@@ -1,0 +1,9 @@
+name: 'NIDirect site themes'
+type: module
+description: 'Display a searchable list of all site themes.'
+core: 8.x
+package: 'NIDirect'
+dependencies:
+  - drupal:taxonomy
+  - taxonomy_manager
+  - taxonomy_access_fix

--- a/nidirect_site_themes/nidirect_site_themes.module
+++ b/nidirect_site_themes/nidirect_site_themes.module
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @file
+ * Hook functions for nidirect_site_themes module.
+ */
+
+/**
+ * Implements hook_preprocess_item_list().
+ *
+ * We use this to manipulate the taxonomy manager options. it doesn't
+ * use form API to generate this list so by preprocessing the theme item
+ * it uses, we can very, very selectively prune off the vocabs the user
+ * isn't allowed to access.
+ *
+ * Anything more substantial, we probably need to re-route the request
+ * to our own controller class.
+ */
+function nidirect_site_themes_preprocess_item_list(&$variables) {
+  if (\Drupal::routeMatch()->getRouteName() != 'taxonomy_manager.admin') {
+    return;
+  }
+
+  foreach ($variables['items'] as $index => $item) {
+    // Extract the term id from the URL (that's all we have to work with at this level).
+    $matches = [];
+    preg_match('#\/admin\/structure\/taxonomy_manager\/voc/(.+)\"#', $item['value']->getGeneratedLink(), $matches);
+    $vocab_id = $matches[1];
+
+    if (\Drupal::currentUser()->hasPermission('edit terms in ' . $vocab_id) == FALSE) {
+      unset($variables['items'][$index]);
+    }
+  }
+}

--- a/nidirect_site_themes/nidirect_site_themes.services.yml
+++ b/nidirect_site_themes/nidirect_site_themes.services.yml
@@ -1,0 +1,5 @@
+services:
+  nidirect_site_themes.taxonomy_route_subscriber:
+    class: Drupal\nidirect_site_themes\Routing\TaxonomyRouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/nidirect_site_themes/src/Routing/TaxonomyRouteSubscriber.php
+++ b/nidirect_site_themes/src/Routing/TaxonomyRouteSubscriber.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Drupal\nidirect_site_themes\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to the dynamic route events.
+ */
+class TaxonomyRouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+
+    // Alter the generic, high level permissions to check whether
+    // the current user can something basic with this vocabulary: eg: edit/add terms.
+    // We make use of taxonony_access_fix's dynamic permissions for this as D8 core's
+    // permissions are too coarse to allow us to limit control to one specific vocabulary.
+    $vocab_routes_to_alter = [
+      'taxonomy_manager.admin_vocabulary',
+      'taxonomy_manager.admin_vocabulary.add',
+      'taxonomy_manager.admin_vocabulary.move',
+      'taxonomy_manager.admin_vocabulary.search',
+      'taxonomy_manager.admin_vocabulary.searchautocomplete',
+    ];
+
+    foreach ($vocab_routes_to_alter as $route_id) {
+      $route = $collection->get($route_id);
+      $route->setRequirements([
+        '_custom_access' => '\Drupal\nidirect_site_themes\TaxonomyVocabAccess::handleAccess',
+      ]);
+    }
+
+    // Amend overview and subtree route access to be a little more relaxed.
+    $general_routes = [
+      'taxonomy_manager.admin',
+      'taxonomy_manager.subTree',
+    ];
+
+    foreach ($general_routes as $route_id) {
+      $route = $collection->get($route_id);
+      $route->setRequirement('_permission', 'access taxonomy overview');
+    }
+  }
+
+}

--- a/nidirect_site_themes/src/TaxonomyVocabAccess.php
+++ b/nidirect_site_themes/src/TaxonomyVocabAccess.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\nidirect_site_themes;
+
+use Drupal\Core\Access\AccessResult;
+
+class TaxonomyVocabAccess {
+
+  /**
+   * Access callback for common CUSTOM taxonomy operations.
+   */
+  public static function handleAccess($taxonomy_vocabulary = NULL) {
+    // Admin: always.
+    if (\Drupal::currentUser()->hasPermission('administer taxonomy')) {
+      return AccessResult::allowed();
+    }
+    else {
+      // Check permissions defined by taxonomy_access_fix; defined per vocab.
+      if (\Drupal::currentUser()->hasPermission('add terms in ' . $taxonomy_vocabulary)) {
+        return AccessResult::allowed();
+      }
+    }
+
+    return AccessResult::forbidden();
+  }
+
+}


### PR DESCRIPTION
Site editors presently have the ability to add/edit/view terms in the site topics (now site themes) vocabulary and this is presented by using `taxonony_access_fix` to make vocab perms more granular and `views_tree` to visualise/present the hierarchy. There are some problems here because: it's not searchable, it's paged and adding terms uses the core taxo forms making for a somewhat janky UX.

This PR compliments another PR that together provides:

- Taxonomy manager contrib module to provide a full, visualised hierarchy of terms, ability to edit/add/move in situ, and search.
- Taxonomy access fix to make per-vocab terms more granular so we can lock off access to non-essential vocabs.
- nidirect_site_themes custom module to fudge about with how taxonomy_manager presents things, using the permissions defined by taxonomy_access_fix for a less confusing UX.