### PR TITLE
D8NID-262 adjust taxo manager permissions

### DIFF
--- a/nidirect_site_themes/nidirect_site_themes.module
+++ b/nidirect_site_themes/nidirect_site_themes.module
@@ -55,12 +55,3 @@ function nidirect_site_themes_form_alter(&$form, FormStateInterface $form_state,
     hide($form['toolbar']['delete']);
   }
 }
-
-/**
- * Implements hook_local_tasks_alter().
- */
-//function nidirect_site_themes_local_tasks_alter(&$local_tasks) {
-//  if (\Drupal::currentUser()->hasPermission('administer taxonomy') == FALSE) {
-//    unset($local_tasks['entity.taxonomy_vocabulary.overview_form']);
-//  }
-//}

--- a/nidirect_site_themes/nidirect_site_themes.module
+++ b/nidirect_site_themes/nidirect_site_themes.module
@@ -5,6 +5,8 @@
  * Hook functions for nidirect_site_themes module.
  */
 
+use Drupal\Core\Form\FormStateInterface;
+
 /**
  * Implements hook_preprocess_item_list().
  *
@@ -22,13 +24,43 @@ function nidirect_site_themes_preprocess_item_list(&$variables) {
   }
 
   foreach ($variables['items'] as $index => $item) {
-    // Extract the term id from the URL (that's all we have to work with at this level).
+    // Extract the vocab id from the URL (that's all we have to work with at this level).
     $matches = [];
     preg_match('#\/admin\/structure\/taxonomy_manager\/voc/(.+)\"#', $item['value']->getGeneratedLink(), $matches);
     $vocab_id = $matches[1];
 
-    if (\Drupal::currentUser()->hasPermission('edit terms in ' . $vocab_id) == FALSE) {
+    if (\Drupal::currentUser()->hasPermission('view terms in ' . $vocab_id) == FALSE) {
       unset($variables['items'][$index]);
     }
   }
 }
+
+/**
+ * Implements hook_form_alter().
+ */
+function nidirect_site_themes_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if ($form_id != 'taxonomy_manager.vocabulary_terms_form') {
+    return;
+  }
+
+  // Look at the requested vocabulary id, alter form controls based on what permissions we have for the user.
+  $taxonomy_vocabulary = \Drupal::routeMatch()->getParameter('$taxonomy_vocabulary');
+
+  $form['toolbar']['add']['#attributes']['disabled'] = \Drupal::currentUser()->hasPermission("add terms in $taxonomy_vocabulary") == FALSE;
+  $form['toolbar']['Search']['#attributes']['disabled'] = \Drupal::currentUser()->hasPermission("view terms in $taxonomy_vocabulary") == FALSE;
+  if (\Drupal::currentUser()->hasPermission("add terms in $taxonomy_vocabulary") == FALSE) {
+    // There's an AJAX callback attached to this (see TaxonomyManagerForm.php) so it's
+    // easier to pretend we've already rendered the element than try to mess about with
+    // the innards of that callback and its handler.
+    hide($form['toolbar']['delete']);
+  }
+}
+
+/**
+ * Implements hook_local_tasks_alter().
+ */
+//function nidirect_site_themes_local_tasks_alter(&$local_tasks) {
+//  if (\Drupal::currentUser()->hasPermission('administer taxonomy') == FALSE) {
+//    unset($local_tasks['entity.taxonomy_vocabulary.overview_form']);
+//  }
+//}

--- a/nidirect_site_themes/nidirect_site_themes.permissions.yml
+++ b/nidirect_site_themes/nidirect_site_themes.permissions.yml
@@ -1,0 +1,5 @@
+view taxonomy terms:
+  title: 'View terms in a vocabulary'
+
+permission_callbacks:
+  - Drupal\nidirect_site_themes\TaxonomyVocabAccess::permissions

--- a/nidirect_site_themes/nidirect_site_themes.services.yml
+++ b/nidirect_site_themes/nidirect_site_themes.services.yml
@@ -2,4 +2,4 @@ services:
   nidirect_site_themes.taxonomy_route_subscriber:
     class: Drupal\nidirect_site_themes\Routing\TaxonomyRouteSubscriber
     tags:
-      - { name: event_subscriber }
+      - { name: event_subscriber, priority: 100 }

--- a/nidirect_site_themes/src/Routing/TaxonomyRouteSubscriber.php
+++ b/nidirect_site_themes/src/Routing/TaxonomyRouteSubscriber.php
@@ -3,6 +3,7 @@
 namespace Drupal\nidirect_site_themes\Routing;
 
 use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
 /**
@@ -20,29 +21,52 @@ class TaxonomyRouteSubscriber extends RouteSubscriberBase {
     // We make use of taxonony_access_fix's dynamic permissions for this as D8 core's
     // permissions are too coarse to allow us to limit control to one specific vocabulary.
     $vocab_routes_to_alter = [
-      'taxonomy_manager.admin_vocabulary',
       'taxonomy_manager.admin_vocabulary.add',
+      'taxonomy_manager.admin_vocabulary.delete',
       'taxonomy_manager.admin_vocabulary.move',
+    ];
+
+    $vocab_routes_for_view_only = [
+      'taxonomy_manager.admin_vocabulary',
+      'taxonomy_manager.subTree',
       'taxonomy_manager.admin_vocabulary.search',
       'taxonomy_manager.admin_vocabulary.searchautocomplete',
     ];
 
+    // Handle top-level admin route by piggybacking on core taxonomy term permission.
+    $route = $collection->get('taxonomy_manager.admin');
+    $route->setRequirement('_permission', 'access taxonomy overview');
+
+    // Per-vocab routes need to be sympathetic to vocab id and operation.
     foreach ($vocab_routes_to_alter as $route_id) {
       $route = $collection->get($route_id);
       $route->setRequirements([
         '_custom_access' => '\Drupal\nidirect_site_themes\TaxonomyVocabAccess::handleAccess',
       ]);
+
+      $route_op = explode('.', $route_id)[2];
+      if (!empty($route_op)) {
+        $route->setOption('op', $route_op);
+      }
     }
 
-    // Amend overview and subtree route access to be a little more relaxed.
-    $general_routes = [
-      'taxonomy_manager.admin',
-      'taxonomy_manager.subTree',
-    ];
-
-    foreach ($general_routes as $route_id) {
+    // These only need 'view' access.
+    foreach ($vocab_routes_for_view_only as $route_id) {
       $route = $collection->get($route_id);
-      $route->setRequirement('_permission', 'access taxonomy overview');
+      $route->setRequirements([
+        '_custom_access' => '\Drupal\nidirect_site_themes\TaxonomyVocabAccess::handleAccess',
+      ]);
+      $route->setOption('op', 'view');
+    }
+
+    // Set the permission so that to see the core Taxonomy vocabs overview you need the
+    // administer taxonomy permission, rather than that or the access taxonomy overview
+    // permission which we're extending to cover Taxonomy Manager.
+    if ($route = $collection->get('entity.taxonomy_vocabulary.collection')) {
+      $route->setRequirements([
+        '_permission' => 'administer taxonomy',
+      ]);
+      $route->setOption('_access_checks', 'access_check.permission');
     }
   }
 

--- a/nidirect_site_themes/src/TaxonomyVocabAccess.php
+++ b/nidirect_site_themes/src/TaxonomyVocabAccess.php
@@ -3,8 +3,12 @@
 namespace Drupal\nidirect_site_themes;
 
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\taxonomy\Entity\Vocabulary;
 
 class TaxonomyVocabAccess {
+
+  use StringTranslationTrait;
 
   /**
    * Access callback for common CUSTOM taxonomy operations.
@@ -15,13 +19,34 @@ class TaxonomyVocabAccess {
       return AccessResult::allowed();
     }
     else {
-      // Check permissions defined by taxonomy_access_fix; defined per vocab.
-      if (\Drupal::currentUser()->hasPermission('add terms in ' . $taxonomy_vocabulary)) {
+      // What option have we set? It's based on path.
+      $op = \Drupal::routeMatch()->getRouteObject()->getOption('op');
+
+      if (\Drupal::currentUser()->hasPermission("$op terms in $taxonomy_vocabulary")) {
         return AccessResult::allowed();
       }
     }
 
     return AccessResult::forbidden();
+  }
+
+  /**
+   * Get permissions.
+   *
+   * @return array
+   *   Permissions array.
+   */
+  public function permissions() {
+    $permissions = [];
+
+    foreach (Vocabulary::loadMultiple() as $vocabulary) {
+      $id = $vocabulary->id();
+      $args = ['%vocabulary' => $vocabulary->label()];
+
+      $permissions["view terms in $id"] = ['title' => $this->t('%vocabulary: View terms', $args)];
+    }
+
+    return $permissions;
   }
 
 }


### PR DESCRIPTION
TODO:

- Work out why routesubscriber/alter doesn't correctly supersede the one from taxonomy_access_fix
- Rename nidirect_site_themes to something more taxonomy vocab agnostic.
- Prune off any vocab admin related links from taxonomy_manager that non-admin roles can't use so shouldn't see.