### PR TITLE
Move 'GPs' menu option down to secondary tab on content page

### DIFF
--- a/nidirect_gp/nidirect_gp.links.task.yml
+++ b/nidirect_gp/nidirect_gp.links.task.yml
@@ -1,10 +1,4 @@
 # GP routing definition
-gp.collection:
-  title: 'GPs'
-  route_name: entity.gp.collection
-  description: 'Show GP list'
-  base_route: system.admin_content
-
 gp.settings_tab:
   route_name: gp.settings
   title: 'Settings'


### PR DESCRIPTION
Re design of user dashboard, centralise everything around the main admin content view.