### PR TITLE
Add new breadcrumb builder class and render closures element

### DIFF
--- a/nidirect_breadcrumbs/nidirect_breadcrumbs.services.yml
+++ b/nidirect_breadcrumbs/nidirect_breadcrumbs.services.yml
@@ -39,8 +39,15 @@ services:
     arguments: ['%breadcrumb.search.matches%']
     tags:
       - { name: breadcrumb_builder }
+  nidirect_breadcrumbs.breadcrumb.schoolclosures:
+    class: Drupal\nidirect_breadcrumbs\SchoolClosuresBreadcrumb
+    arguments: ['%breadcrumb.schoolclosures.matches%', '@path.alias_manager', '@request_stack']
+    tags:
+      - { name: breadcrumb_builder }
 
 parameters:
   breadcrumb.search.matches:
     - view.search.page_1
     - view.publications.search_page
+  breadcrumb.schoolclosures.matches:
+    - /services/school-closures

--- a/nidirect_breadcrumbs/src/SchoolClosuresBreadcrumb.php
+++ b/nidirect_breadcrumbs/src/SchoolClosuresBreadcrumb.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Drupal\nidirect_breadcrumbs;
+
+/**
+ * @file
+ * Generates the breadcrumb trail for school closure page(s)
+ */
+
+use Drupal\Core\Breadcrumb\Breadcrumb;
+use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Path\AliasManagerInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Breadcrumb builder class to assemble breadcrumb trail
+ * for paths relating to school closures.
+ *
+ * @package Drupal\nidirect_breadcrumbs
+ */
+class SchoolClosuresBreadcrumb implements BreadcrumbBuilderInterface {
+
+  /**
+   * Path alias manager service.
+   *
+   * @var \Drupal\Core\Path\AliasManagerInterface
+   */
+  protected $aliasManager;
+
+  /**
+   * Request stack service.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * Class constructor.
+   */
+  public function __construct(array $route_matches, AliasManagerInterface $path_alias_manager, RequestStack $request_stack) {
+    $this->routeMatches = $route_matches;
+    $this->aliasManager = $path_alias_manager;
+    $this->requestStack = $request_stack;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('breadcrumb.schoolclosures.matches'),
+      $container->get('path.alias_manager'),
+      $container->get('request_stack')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies(RouteMatchInterface $route_match) {
+    $match = FALSE;
+
+    if (in_array($this->requestStack->getCurrentRequest()->getPathInfo(), $this->routeMatches)) {
+      $match = TRUE;
+    }
+
+    return $match;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(RouteMatchInterface $route_match) {
+
+    $breadcrumb = new Breadcrumb();
+    $links[] = Link::createFromRoute(t('Home'), '<front>');
+    // TODO: replace fixed text/paths with routes to actual nodes or taxonomy term pages.
+    $links[] = Link::fromTextAndUrl('Education', Url::fromUserInput('/information-and-services/education'));
+    $links[] = Link::fromTextAndUrl('Schools, learning and development', Url::fromUserInput('/information-and-services/education/schools-learning-and-development'));
+    $links[] = Link::fromTextAndUrl('School life', Url::fromUserInput('/information-and-services/schools-learning-and-development/school-life'));
+    $breadcrumb->setLinks($links);
+    $breadcrumb->addCacheContexts(['url.path']);
+
+    return $breadcrumb;
+  }
+
+}

--- a/nidirect_school_closures/nidirect_school_closures.module
+++ b/nidirect_school_closures/nidirect_school_closures.module
@@ -5,6 +5,8 @@
  * Contains nidirect_school_closures.module.
  */
 
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Render\BubbleableMetadata;
 
@@ -90,4 +92,17 @@ function nidirect_school_closures_render() {
     '#updated' => $service->getUpdated(),
     '#attached' => ['library' => 'nidirect_school_closures/school_closures'],
   ];
+}
+
+/**
+ * Implements hook_entity_view().
+ */
+function nidirect_school_closures_entity_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
+  $current_path = \Drupal::request()->getPathInfo();
+  $closures_paths = \Drupal::getContainer()->getParameter('breadcrumb.schoolclosures.matches');
+
+  if (in_array($current_path, $closures_paths) && ($entity instanceof NodeInterface && $view_mode == 'full')) {
+    // Append the school closures info to the render array for this page.
+    $build['closures_info'] = nidirect_school_closures_render();
+  }
 }


### PR DESCRIPTION
- Use service container parameters to define path match for specific
page(s) to display the breadcrumb and/or closures details on.

Haven't touched the WYSIWYG profiles to use the token embed button which was the originally expected route for this to take.