### PR TITLE
Fix nightwatch tests for breadcrumbs on node types.

### DIFF
--- a/nidirect_breadcrumbs/src/ContactBreadcrumb.php
+++ b/nidirect_breadcrumbs/src/ContactBreadcrumb.php
@@ -64,11 +64,14 @@ class ContactBreadcrumb implements BreadcrumbBuilderInterface {
 
     $route_name = $route_match->getRouteName();
 
-    if ($route_name == 'entity.node.canonical') {
+    if ($route_name == 'entity.node.canonical' && !empty($route_match->getParameter('node'))) {
       $this->node = $route_match->getParameter('node');
 
       if ($this->node instanceof NodeInterface == FALSE) {
         $this->node = $this->entityTypeManager->getStorage('node')->load($this->node);
+      }
+
+      if (!empty($this->node)) {
         $match = $this->node->bundle() == 'contact';
       }
     }

--- a/nidirect_breadcrumbs/src/GpPracticeBreadcrumb.php
+++ b/nidirect_breadcrumbs/src/GpPracticeBreadcrumb.php
@@ -68,11 +68,14 @@ class GpPracticeBreadcrumb implements BreadcrumbBuilderInterface {
 
     $route_name = $route_match->getRouteName();
 
-    if ($route_name == 'entity.node.canonical') {
+    if ($route_name == 'entity.node.canonical' && !empty($route_match->getParameter('node'))) {
       $this->node = $route_match->getParameter('node');
 
       if ($this->node instanceof NodeInterface == FALSE) {
         $this->node = $this->entityTypeManager->getStorage('node')->load($this->node);
+      }
+
+      if (!empty($this->node)) {
         $match = $this->node->bundle() == 'gp_practice';
       }
     }

--- a/nidirect_breadcrumbs/src/HealthConditionBreadcrumb.php
+++ b/nidirect_breadcrumbs/src/HealthConditionBreadcrumb.php
@@ -68,7 +68,7 @@ class HealthConditionBreadcrumb implements BreadcrumbBuilderInterface {
 
     $route_name = $route_match->getRouteName();
 
-    if ($route_name == 'entity.node.canonical') {
+    if ($route_name == 'entity.node.canonical' && !empty($route_match->getParameter('node'))) {
       $this->node = $route_match->getParameter('node');
 
       if ($this->node instanceof NodeInterface == FALSE) {

--- a/nidirect_breadcrumbs/src/NewsBreadcrumb.php
+++ b/nidirect_breadcrumbs/src/NewsBreadcrumb.php
@@ -62,7 +62,7 @@ class NewsBreadcrumb implements BreadcrumbBuilderInterface {
 
     $route_name = $route_match->getRouteName();
 
-    if ($route_name == 'entity.node.canonical') {
+    if ($route_name == 'entity.node.canonical' && !empty($route_match->getParameter('node'))) {
       $this->node = $route_match->getParameter('node');
 
       if ($this->node instanceof NodeInterface == FALSE) {

--- a/nidirect_breadcrumbs/src/RecipeBreadcrumb.php
+++ b/nidirect_breadcrumbs/src/RecipeBreadcrumb.php
@@ -68,7 +68,7 @@ class RecipeBreadcrumb implements BreadcrumbBuilderInterface {
 
     $route_name = $route_match->getRouteName();
 
-    if ($route_name == 'entity.node.canonical') {
+    if ($route_name == 'entity.node.canonical' && !empty($route_match->getParameter('node'))) {
       $this->node = $route_match->getParameter('node');
 
       if ($this->node instanceof NodeInterface == FALSE) {

--- a/nidirect_breadcrumbs/src/UmbrellaBodyBreadcrumb.php
+++ b/nidirect_breadcrumbs/src/UmbrellaBodyBreadcrumb.php
@@ -66,7 +66,7 @@ class UmbrellaBodyBreadcrumb implements BreadcrumbBuilderInterface {
 
     $route_name = $route_match->getRouteName();
 
-    if ($route_name == 'entity.node.canonical') {
+    if ($route_name == 'entity.node.canonical' && !empty($route_match->getParameter('node'))) {
       $this->node = $route_match->getParameter('node');
 
       if ($this->node instanceof NodeInterface == FALSE) {

--- a/nidirect_breadcrumbs/tests/src/Nightwatch/Tests/applicationBreadcrumbBuilder.js
+++ b/nidirect_breadcrumbs/tests/src/Nightwatch/Tests/applicationBreadcrumbBuilder.js
@@ -24,7 +24,7 @@ module.exports = {
   'Test that Application node shows correct breadcrumb pattern': browser => {
     browser
       .pause(2000, function () {
-        browser.drupalRelativeURL('/node/' + nid).waitForElementVisible('body', 1000);
+        browser.drupalRelativeURL('/node/' + nid).waitForElementVisible('body', 2000);
 
         console.log('Evaluating output for node id (' + nid + '): ' + node.title);
 
@@ -33,7 +33,7 @@ module.exports = {
         console.log('Migration node endpoint provided these subtheme terms: ' + subthemesHierarchy.toString());
 
         for (let i = 0; i < subthemesHierarchy.length; i++) {
-          browser.expect.element('nav.breadcrumb').text.to.contain(subthemesHierarchy[i]);
+          browser.expect.element('nav.breadcrumb .breadcrumb--list').text.to.contain(subthemesHierarchy[i]);
         }
 
       })

--- a/nidirect_breadcrumbs/tests/src/Nightwatch/Tests/contactBreadcrumbBuilder.js
+++ b/nidirect_breadcrumbs/tests/src/Nightwatch/Tests/contactBreadcrumbBuilder.js
@@ -26,8 +26,8 @@ module.exports = {
       .pause(2000, function () {
         browser
           .drupalRelativeURL('/node/' + nid)
-          .waitForElementVisible('body', 1000)
-          .expect.element('nav.breadcrumb')
+          .waitForElementVisible('body', 2000)
+          .expect.element('nav.breadcrumb .breadcrumb--list')
           .to.have.text.to.match(/(Home)\W+(Contacts)$/);
       })
   }

--- a/nidirect_breadcrumbs/tests/src/Nightwatch/Tests/gpPracticeBreadcrumbBuilder.js
+++ b/nidirect_breadcrumbs/tests/src/Nightwatch/Tests/gpPracticeBreadcrumbBuilder.js
@@ -33,10 +33,10 @@ module.exports = {
       .pause(2000, function () {
         browser
           .drupalRelativeURL('/node/' + nid)
-          .waitForElementVisible('body', 1000);
+          .waitForElementVisible('body', 2000);
 
         breadcrumbSegments.forEach(function (item) {
-          browser.expect.element('nav.breadcrumb').text.to.contain(item);
+          browser.expect.element('nav.breadcrumb .breadcrumb--list').text.to.contain(item);
         });
       })
   }

--- a/nidirect_breadcrumbs/tests/src/Nightwatch/Tests/healthConditionBreadcrumbBuilder.js
+++ b/nidirect_breadcrumbs/tests/src/Nightwatch/Tests/healthConditionBreadcrumbBuilder.js
@@ -32,10 +32,10 @@ module.exports = {
       .pause(2000, function () {
         browser
           .drupalRelativeURL('/node/' + nid)
-          .waitForElementVisible('body', 1000);
+          .waitForElementVisible('body', 2000);
 
         breadcrumbSegments.forEach(function (item) {
-          browser.expect.element('nav.breadcrumb').text.to.contain(item);
+          browser.expect.element('nav.breadcrumb .breadcrumb--list').text.to.contain(item);
         });
       })
   }

--- a/nidirect_breadcrumbs/tests/src/Nightwatch/Tests/newsBreadcrumbBuilder.js
+++ b/nidirect_breadcrumbs/tests/src/Nightwatch/Tests/newsBreadcrumbBuilder.js
@@ -10,7 +10,7 @@ module.exports = {
   '@tags': ['nidirect-breadcrumbs'],
 
   before: function (browser) {
-    // GP Practice nodes.
+    // News nodes.
     http.get(process.env.TEST_D7_URL + '/migrate/news', (response) => {
       let data = '';
       response.on('data', (chunk) => { data += chunk });
@@ -30,11 +30,8 @@ module.exports = {
       .pause(2000, function () {
         browser
           .drupalRelativeURL('/node/' + nid)
-          .waitForElementVisible('body', 1000);
-
-        breadcrumbSegments.forEach(function (item) {
-          browser.expect.element('nav.breadcrumb').text.to.contain(item);
-        });
+          .waitForElementVisible('body', 2000)
+          .expect.element('nav.breadcrumb .breadcrumb--list').to.have.text.to.match(/(Home)\W+(News)$/);
       })
   }
 

--- a/nidirect_breadcrumbs/tests/src/Nightwatch/Tests/recipeBreadcrumbBuilder.js
+++ b/nidirect_breadcrumbs/tests/src/Nightwatch/Tests/recipeBreadcrumbBuilder.js
@@ -32,10 +32,10 @@ module.exports = {
       .pause(2000, function () {
         browser
           .drupalRelativeURL('/node/' + nid)
-          .waitForElementVisible('body', 1000);
+          .waitForElementVisible('body', 2000);
 
         breadcrumbSegments.forEach(function (item) {
-          browser.expect.element('nav.breadcrumb').text.to.contain(item);
+          browser.expect.element('nav.breadcrumb .breadcrumb--list').text.to.contain(item);
         });
       })
   }


### PR DESCRIPTION
- Amend CSS selector + timeout limits on nightwatch tests.
- Make breadcrumb builder classes consistent for checking node values
and bundle types