### PR TITLE
D8 nid 367

### DIFF
--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -222,6 +222,22 @@ function nidirect_common_node_delete(EntityInterface $entity) {
 }
 
 /**
+ * Implements hook_ENTITY_TYPE_presave() for taxonomy_term entities.
+ */
+function nidirect_common_taxonomy_term_presave(EntityInterface $entity) {
+  // Invalidate 'taxonomy_term_list' custom cache tag for the
+  // parent when a new taxonomy term is created.
+  if ($entity->get('vid')->target_id == 'site_themes') {
+    if ($entity->isNewRevision()) {
+      $parent = $entity->get('parent')->target_id;
+      if ($parent) {
+        Cache::invalidateTags(['taxonomy_term_list:' . $parent]);
+      }
+    }
+  }
+}
+
+/**
  * Invalidate taxonomy cache tags.
  */
 function _invalidate_theme_cache_tags($entity) {

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -207,7 +207,6 @@ function nidirect_common_node_view(array &$build, EntityInterface $entity, Entit
 function nidirect_common_node_presave(EntityInterface $entity) {
   // Check that the node is published.
   if ($entity->get('status')->value) {
-    //_invalidate_theme_cache_tags($entity);
     $cache_service = \Drupal::service('nidirect_common.invalidate_taxonomy_list_cache_tags');
     $cache_service->invalidateForEntity($entity);
   }
@@ -219,7 +218,6 @@ function nidirect_common_node_presave(EntityInterface $entity) {
  * Invalidate taxonomy cache tags after node deletion.
  */
 function nidirect_common_node_delete(EntityInterface $entity) {
-  //_invalidate_theme_cache_tags($entity);
   $cache_service = \Drupal::service('nidirect_common.invalidate_taxonomy_list_cache_tags');
   $cache_service->invalidateForEntity($entity);
 }
@@ -237,35 +235,5 @@ function nidirect_common_taxonomy_term_presave(EntityInterface $entity) {
         Cache::invalidateTags(['taxonomy_term_list:' . $parent]);
       }
     }
-  }
-}
-
-/**
- * Invalidate taxonomy cache tags.
- */
-function _invalidate_theme_cache_tags($entity) {
-  // If a node references any point in the 'site themes'
-  // vocabulary, make sure that the appropriate taxonomy
-  // cache tags are invalidated.
-  $field_list = ['field_subtheme', 'field_site_themes'];
-  $taxonomy_tags = [];
-  foreach ($field_list as $thisfield) {
-    if ($entity->hasField($thisfield)) {
-      $tid = $entity->get($thisfield)->target_id;
-      if (isset($tid)) {
-        $taxonomy_tags[] = 'taxonomy_term_list:' . $tid;
-      }
-      // If this is an update, invalidate cache tag for
-      // original taxonomy term as well.
-      if (isset($entity->original)) {
-        $tid = $entity->original->get($thisfield)->target_id;
-        if (isset($tid)) {
-          $taxonomy_tags[] = 'taxonomy_term_list:' . $tid;
-        }
-      }
-    }
-  }
-  if (count($taxonomy_tags) > 0) {
-    Cache::invalidateTags($taxonomy_tags);
   }
 }

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -31,7 +31,6 @@ function nidirect_common_help($route_name, RouteMatchInterface $route_match) {
 
 /**
  * Implements hook_cron().
- *
  */
 function nidirect_common_cron() {
   // Process anything in the 'audit_date_updates' queue which was
@@ -53,8 +52,8 @@ function nidirect_common_cron() {
         foreach ($nodes as $node) {
           // Double check that auditing is enabled for this content type.
           if ($node->hasField('field_next_audit_due')) {
-            // Just set next audit date to today as will show in 'needs audit' report
-            // if next audit date is today or earlier.
+            // Just set next audit date to today as will show in 'needs audit'
+            // report if next audit date is today or earlier.
             $node->set('field_next_audit_due', $today);
             $node->save();
           }
@@ -119,7 +118,7 @@ function nidirect_common_views_pre_render(ViewExecutable $view) {
       '#markup' => \Drupal::translation()->formatPlural(
         $view->pager->total_items,
         '@number recipe',
-        '@number recipes', ['@number' => $view->pager->total_items])
+        '@number recipes', ['@number' => $view->pager->total_items]),
     ];
   }
 
@@ -246,7 +245,7 @@ function _invalidate_theme_cache_tags($entity) {
   // cache tags are invalidated.
   $field_list = ['field_subtheme', 'field_site_themes'];
   $taxonomy_tags = [];
-  foreach($field_list as $thisfield) {
+  foreach ($field_list as $thisfield) {
     if ($entity->hasField($thisfield)) {
       $tid = $entity->get($thisfield)->target_id;
       if (isset($tid)) {

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -5,6 +5,7 @@
  * Contains nidirect_common.module.
  */
 
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
@@ -196,5 +197,51 @@ function nidirect_common_node_view(array &$build, EntityInterface $entity, Entit
 
   if ($entity->bundle() == 'publication' && $view_mode == 'search_result') {
     $build['field_published_date']['#title'] = t('Published');
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_presave().
+ *
+ * Invalidate taxonomy cache tags after node save.
+ */
+function nidirect_common_node_presave(EntityInterface $entity) {
+  // Check that the node is published.
+  if ($entity->get('status')->value) {
+    _invalidate_theme_cache_tags($entity);
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_delete().
+ *
+ * Invalidate taxonomy cache tags after node deletion.
+ */
+function nidirect_common_node_delete(EntityInterface $entity) {
+  _invalidate_theme_cache_tags($entity);
+}
+
+/**
+ * Invalidate taxonomy cache tags.
+ */
+function _invalidate_theme_cache_tags($entity) {
+  // If a node references any point in the 'site themes'
+  // vocabulary, make sure that the appropriate taxonomy
+  // cache tags are invalidated.
+  $taxonomy_tags = [];
+  if ($entity->hasField('field_subtheme')) {
+    $tid = $entity->get('field_subtheme')->target_id;
+    if (isset($tid)) {
+      $taxonomy_tags[] = 'taxonomy_term:' . $tid;
+    }
+  }
+  if ($entity->hasField('field_site_themes')) {
+    $tid = $entity->get('field_site_themes')->target_id;
+    if (isset($tid)) {
+      $taxonomy_tags[] = 'taxonomy_term:' . $tid;
+    }
+  }
+  if (count($taxonomy_tags) > 0) {
+    Cache::invalidateTags($taxonomy_tags);
   }
 }

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -228,17 +228,22 @@ function _invalidate_theme_cache_tags($entity) {
   // If a node references any point in the 'site themes'
   // vocabulary, make sure that the appropriate taxonomy
   // cache tags are invalidated.
+  $field_list = ['field_subtheme', 'field_site_themes'];
   $taxonomy_tags = [];
-  if ($entity->hasField('field_subtheme')) {
-    $tid = $entity->get('field_subtheme')->target_id;
-    if (isset($tid)) {
-      $taxonomy_tags[] = 'taxonomy_term:' . $tid;
-    }
-  }
-  if ($entity->hasField('field_site_themes')) {
-    $tid = $entity->get('field_site_themes')->target_id;
-    if (isset($tid)) {
-      $taxonomy_tags[] = 'taxonomy_term:' . $tid;
+  foreach($field_list as $thisfield) {
+    if ($entity->hasField($thisfield)) {
+      $tid = $entity->get($thisfield)->target_id;
+      if (isset($tid)) {
+        $taxonomy_tags[] = 'taxonomy_term_list:' . $tid;
+      }
+      // If this is an update, invalidate cache tag for
+      // original taxonomy term as well.
+      if (isset($entity->original)) {
+        $tid = $entity->original->get($thisfield)->target_id;
+        if (isset($tid)) {
+          $taxonomy_tags[] = 'taxonomy_term_list:' . $tid;
+        }
+      }
     }
   }
   if (count($taxonomy_tags) > 0) {

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -207,7 +207,9 @@ function nidirect_common_node_view(array &$build, EntityInterface $entity, Entit
 function nidirect_common_node_presave(EntityInterface $entity) {
   // Check that the node is published.
   if ($entity->get('status')->value) {
-    _invalidate_theme_cache_tags($entity);
+    //_invalidate_theme_cache_tags($entity);
+    $cache_service = \Drupal::service('nidirect_common.invalidate_taxonomy_list_cache_tags');
+    $cache_service->invalidateForEntity($entity);
   }
 }
 
@@ -217,7 +219,9 @@ function nidirect_common_node_presave(EntityInterface $entity) {
  * Invalidate taxonomy cache tags after node deletion.
  */
 function nidirect_common_node_delete(EntityInterface $entity) {
-  _invalidate_theme_cache_tags($entity);
+  //_invalidate_theme_cache_tags($entity);
+  $cache_service = \Drupal::service('nidirect_common.invalidate_taxonomy_list_cache_tags');
+  $cache_service->invalidateForEntity($entity);
 }
 
 /**

--- a/nidirect_common/nidirect_common.services.yml
+++ b/nidirect_common/nidirect_common.services.yml
@@ -1,0 +1,7 @@
+services:
+  logger.channel.nidirect_common:
+    parent: logger.channel_base
+    arguments: ['nidirect_common']
+  nidirect_common.invalidate_taxonomy_list_cache_tags:
+    class: Drupal\nidirect_common\InvalidateTaxonomyListCacheTags
+    arguments: []

--- a/nidirect_common/nidirect_common.services.yml
+++ b/nidirect_common/nidirect_common.services.yml
@@ -1,7 +1,4 @@
 services:
-  logger.channel.nidirect_common:
-    parent: logger.channel_base
-    arguments: ['nidirect_common']
   nidirect_common.invalidate_taxonomy_list_cache_tags:
     class: Drupal\nidirect_common\InvalidateTaxonomyListCacheTags
     arguments: []

--- a/nidirect_common/nidirect_common.services.yml
+++ b/nidirect_common/nidirect_common.services.yml
@@ -1,4 +1,4 @@
 services:
   nidirect_common.invalidate_taxonomy_list_cache_tags:
     class: Drupal\nidirect_common\InvalidateTaxonomyListCacheTags
-    arguments: []
+    arguments: ['@cache_tags.invalidator']

--- a/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
+++ b/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
@@ -3,6 +3,7 @@
 namespace Drupal\nidirect_common;
 
 use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\Core\Entity\EntityInterface;
 
 /**
  * Class InvalidateTaxonomyListCacheTags.
@@ -22,7 +23,7 @@ class InvalidateTaxonomyListCacheTags {
   /**
    * Invalidate custom cache tags for this entity.
    */
-  public function invalidateForEntity($entity) {
+  public function invalidateForEntity(EntityInterface $entity) {
     // If a node references any point in the 'site themes'
     // vocabulary, make sure that the appropriate taxonomy
     // cache tags are invalidated.

--- a/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
+++ b/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\nidirect_common;
+
+use Drupal\Core\Cache\Cache;
+
+/**
+ * Class InvalidateTaxonomyListCacheTags.
+ */
+class InvalidateTaxonomyListCacheTags {
+
+  /**
+   * Constructs a new InvalidateTaxonomyListCacheTags object.
+   */
+  public function __construct() {
+
+  }
+
+  public function invalidateForEntity($entity) {
+    // If a node references any point in the 'site themes'
+    // vocabulary, make sure that the appropriate taxonomy
+    // cache tags are invalidated.
+    $field_list = ['field_subtheme', 'field_site_themes'];
+    $taxonomy_tags = [];
+    foreach ($field_list as $thisfield) {
+      if ($entity->hasField($thisfield)) {
+        $tid = $entity->get($thisfield)->target_id;
+        if (isset($tid)) {
+          $taxonomy_tags[] = 'taxonomy_term_list:' . $tid;
+        }
+        // If this is an update, invalidate cache tag for
+        // original taxonomy term as well.
+        if (isset($entity->original)) {
+          $tid = $entity->original->get($thisfield)->target_id;
+          if (isset($tid)) {
+            $taxonomy_tags[] = 'taxonomy_term_list:' . $tid;
+          }
+        }
+      }
+    }
+    if (count($taxonomy_tags) > 0) {
+      Cache::invalidateTags($taxonomy_tags);
+    }
+  }
+
+}

--- a/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
+++ b/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
@@ -9,13 +9,6 @@ use Drupal\Core\Cache\Cache;
  */
 class InvalidateTaxonomyListCacheTags {
 
-  /**
-   * Constructs a new InvalidateTaxonomyListCacheTags object.
-   */
-  public function __construct() {
-
-  }
-
   public function invalidateForEntity($entity) {
     // If a node references any point in the 'site themes'
     // vocabulary, make sure that the appropriate taxonomy

--- a/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
+++ b/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
@@ -9,6 +9,9 @@ use Drupal\Core\Cache\Cache;
  */
 class InvalidateTaxonomyListCacheTags {
 
+  /**
+   * Invalidate custom cache tags for this entity.
+   */
   public function invalidateForEntity($entity) {
     // If a node references any point in the 'site themes'
     // vocabulary, make sure that the appropriate taxonomy

--- a/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
+++ b/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
@@ -2,12 +2,22 @@
 
 namespace Drupal\nidirect_common;
 
-use Drupal\Core\Cache\Cache;
+use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
 
 /**
  * Class InvalidateTaxonomyListCacheTags.
  */
 class InvalidateTaxonomyListCacheTags {
+
+  /**
+   * Constructs a new \Drupal\Core\Menu\MenuTreeStorage.
+   *
+   * @param \Drupal\Core\Cache\CacheTagsInvalidatorInterface $cache_tags_invalidator
+   *   The cache tags invalidator.
+   */
+  public function __construct(CacheTagsInvalidatorInterface $cache_tags_invalidator) {
+    $this->cacheTagsInvalidator = $cache_tags_invalidator;
+  }
 
   /**
    * Invalidate custom cache tags for this entity.
@@ -35,7 +45,7 @@ class InvalidateTaxonomyListCacheTags {
       }
     }
     if (count($taxonomy_tags) > 0) {
-      Cache::invalidateTags($taxonomy_tags);
+      $this->cacheTagsInvalidator->invalidateTags($taxonomy_tags);
     }
   }
 


### PR DESCRIPTION
Add hooks to invalidate custom cache tags for taxonomy term view pages.

See other associated PRs:

- https://github.com/dof-dss/nicsdru_nidirect_theme/pull/19/files (preprocess function)
- https://github.com/dof-dss/nidirect-drupal/pull/107 (new views)