### PR TITLE
Campaign aliases

### DIFF
--- a/nidirect_common/nidirect_common.services.yml
+++ b/nidirect_common/nidirect_common.services.yml
@@ -1,4 +1,4 @@
 services:
   nidirect_common.invalidate_taxonomy_list_cache_tags:
     class: Drupal\nidirect_common\InvalidateTaxonomyListCacheTags
-    arguments: ['@cache_tags.invalidator']
+    arguments: ['@cache_tags.invalidator', '@entity_type.manager']

--- a/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
+++ b/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
@@ -75,12 +75,12 @@ class InvalidateTaxonomyListCacheTags {
   /**
    * Get parent taxonomy term for landing pages.
    */
-  private function checkLandingPageParent($entity, $tid) {
+  private function checkLandingPageParent(EntityInterface $entity, int $tid) {
     // Landing page is a special case.
     if ($entity->type->target_id == 'landing_page') {
       // In this case we want to invalidate the cache tag for
       // the parent of the current term.
-      $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($tid);
+      $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($tid);
       if (isset($term->parent->target_id)) {
         $tid = $term->parent->target_id;
       }

--- a/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
+++ b/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
@@ -89,4 +89,3 @@ class InvalidateTaxonomyListCacheTags {
   }
 
 }
-

--- a/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
+++ b/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
@@ -11,6 +11,13 @@ use Drupal\Core\Entity\EntityInterface;
 class InvalidateTaxonomyListCacheTags {
 
   /**
+   * The cache tags invalidator.
+   *
+   * @var \Drupal\Core\Cache\CacheTagsInvalidatorInterface
+   */
+  protected $cacheTagsInvalidator;
+
+  /**
    * Constructs a new \Drupal\Core\Menu\MenuTreeStorage.
    *
    * @param \Drupal\Core\Cache\CacheTagsInvalidatorInterface $cache_tags_invalidator


### PR DESCRIPTION
Add cache invalidation processing for parent term of campaign

Associated PRs:

dof-dss/nidirect-site-modules#108 - add view display for campaigns

dof-dss/nicsdru_nidirect_theme#20 - allow for campaigns overriding taxonomy terms on listing pages