### PR TITLE
D8NID-379: error on search plugin usage

### DIFF
--- a/nidirect_driving_instructors/nidirect_driving_instructors.module
+++ b/nidirect_driving_instructors/nidirect_driving_instructors.module
@@ -99,7 +99,8 @@ function nidirect_driving_instructors_entity_presave(EntityInterface $entity) {
  * Implements hook_search_api_query_alter().
  */
 function nidirect_driving_instructors_search_api_query_alter(QueryInterface $query) {
-  if ($query->getDisplayPlugin()->getPluginDefinition()['view_display'] == "driving_instructor_results") {
+  $display_plugin = $query->getDisplayPlugin();
+  if (!empty($display_plugin) && $display_plugin->getPluginDefinition()['view_display'] == "driving_instructor_results") {
     $keys = $query->getKeys();
 
     // If present remove the second part of any postcode entry as we only want


### PR DESCRIPTION
Ensure search plugin exists before trying to invoke a function on it, avoids tripping a null error