### PR TITLE
Preprocess entity embed elements to swap between dynamic and static maps

### DIFF
--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -252,3 +252,18 @@ function nidirect_common_form_alter(&$form, FormStateInterface $form_state, $for
     }
   }
 }
+
+/**
+ * Implements hook_entity_embed_alter().
+ */
+function nidirect_common_entity_embed_alter(array &$build, EntityInterface $entity, array &$context) {
+  if (\Drupal::routeMatch()->getRouteName() == 'entity.node.canonical') {
+    // Swap between entity embed view modes depending on whether you're viewing or editing nodes.
+    // Dynamic iframes are prohibited in CKEditor which breaks the display of maps for editors, so we
+    // swap view mode to use a static map instead.
+    $context['data-entity-embed-display'] = str_replace('.preview', '.default', $context['data-entity-embed-display']);
+    $build['#context']['data-entity-embed-display'] = str_replace('.preview', '.default', $build['#context']['data-entity-embed-display']);
+    $build['#attributes']['data-entity-embed-display'] = str_replace('.preview', '.default', $build['#attributes']['data-entity-embed-display']);
+    $build['entity']['#view_mode'] = 'default';
+  }
+}

--- a/nidirect_gp/src/Form/GpRevisionRevertForm.php
+++ b/nidirect_gp/src/Form/GpRevisionRevertForm.php
@@ -31,7 +31,7 @@ class GpRevisionRevertForm extends ConfirmFormBase {
    *
    * @var \Drupal\Core\Entity\EntityStorageInterface
    */
-  protected $GpStorage;
+  protected $gpStorage;
 
   /**
    * The date formatter service.
@@ -49,7 +49,7 @@ class GpRevisionRevertForm extends ConfirmFormBase {
    *   The date formatter service.
    */
   public function __construct(EntityStorageInterface $entity_storage, DateFormatterInterface $date_formatter) {
-    $this->GpStorage = $entity_storage;
+    $this->gpStorage = $entity_storage;
     $this->dateFormatter = $date_formatter;
   }
 
@@ -102,7 +102,7 @@ class GpRevisionRevertForm extends ConfirmFormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state, $gp_revision = NULL) {
-    $this->revision = $this->GpStorage->loadRevision($gp_revision);
+    $this->revision = $this->gpStorage->loadRevision($gp_revision);
     $form = parent::buildForm($form, $form_state);
 
     return $form;

--- a/nidirect_gp/src/Form/GpRevisionRevertTranslationForm.php
+++ b/nidirect_gp/src/Form/GpRevisionRevertTranslationForm.php
@@ -94,7 +94,7 @@ class GpRevisionRevertTranslationForm extends GpRevisionRevertForm {
     $revert_untranslated_fields = $form_state->getValue('revert_untranslated_fields');
 
     /** @var \Drupal\nidirect_gp\Entity\GpInterface $default_revision */
-    $latest_revision = $this->GpStorage->load($revision->id());
+    $latest_revision = $this->gpStorage->load($revision->id());
     $latest_revision_translation = $latest_revision->getTranslation($this->langcode);
 
     $revision_translation = $revision->getTranslation($this->langcode);


### PR DESCRIPTION
CKEditor now doesn't permit iframe style dynamic maps in the editorial preview. This code allows us to dynamically switch between Google static maps and (dynamic) Google maps when we move between viewing content and writing content.