### PR TITLE
DNID-405 contacts refinements

### DIFF
--- a/nidirect_contacts/nidirect_contacts.module
+++ b/nidirect_contacts/nidirect_contacts.module
@@ -17,8 +17,8 @@ function nidirect_contacts_form_views_exposed_form_alter(&$form, FormStateInterf
   if ($form['#id'] == 'views-exposed-form-contacts-contact-search') {
     // Make sort options invisible, but because the view embed filters are defined as exposed,
     // we still get to use URL parameters despite having no visible form elements.
-    unset($form['sort_by']);
-    unset($form['sort_order']);
+    hide($form['sort_by']);
+    hide($form['sort_order']);
   }
 
   if ($form['#id'] == 'views-exposed-form-contacts-a-z-contacts-by-letter') {

--- a/nidirect_contacts/nidirect_contacts.module
+++ b/nidirect_contacts/nidirect_contacts.module
@@ -98,6 +98,9 @@ function nidirect_contacts_preprocess_views_view(&$variables) {
       unset($variables['links']['show_az']);
       unset($variables['links']['reset']);
     }
+    else {
+      $variables['exposed']['#info']['filter-title']['label'] = t('Search results for');
+    }
 
     if (($q['sort_by'] ?? '') == 'title') {
       unset($variables['links']['sort_title']);


### PR DESCRIPTION
Use of `unset` meant that views couldn't get at the values of the form elements meaning things like sort ordering weren't working correctly. `hide` sets a flag to say the element has already been rendered, but ensures later form handling can still access the values from those elements.