### PR TITLE
Add news view route name to list of routes covered by nullbreadcrumb

### DIFF
--- a/nidirect_breadcrumbs/nidirect_breadcrumbs.services.yml
+++ b/nidirect_breadcrumbs/nidirect_breadcrumbs.services.yml
@@ -85,3 +85,4 @@ parameters:
   breadcrumb.nullbreadcrumb.matches:
     - /forms/feedback
     - entity.taxonomy_term.canonical
+    - nidirect_news.news_listing

--- a/nidirect_breadcrumbs/src/NewsBreadcrumb.php
+++ b/nidirect_breadcrumbs/src/NewsBreadcrumb.php
@@ -74,11 +74,6 @@ class NewsBreadcrumb implements BreadcrumbBuilderInterface {
       }
     }
 
-    if ($route_name == 'nidirect_news.news_listing') {
-      // Also match on news listing page.
-      $match = TRUE;
-    }
-
     return $match;
   }
 
@@ -89,12 +84,10 @@ class NewsBreadcrumb implements BreadcrumbBuilderInterface {
 
     $breadcrumb = new Breadcrumb();
 
-    if ($this->node) {
-      $links[] = Link::createFromRoute(t('Home'), '<front>');
-      $links[] = Link::fromTextandUrl(t('News'), Url::fromRoute('nidirect_news.news_listing'));
+    $links[] = Link::createFromRoute(t('Home'), '<front>');
+    $links[] = Link::fromTextandUrl(t('News'), Url::fromRoute('nidirect_news.news_listing'));
 
-      $breadcrumb->setLinks($links);
-    }
+    $breadcrumb->setLinks($links);
 
     $breadcrumb->addCacheContexts(['url.path']);
 


### PR DESCRIPTION
Thought this was already working before, but guess not! It is now.