### PR TITLE
D8 nid 460 landing page duplicates and redirectds

### DIFF
--- a/nidirect_common/inc/landing_page.redirects.inc
+++ b/nidirect_common/inc/landing_page.redirects.inc
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Contains functions Layout Builder search indexing.
+ * Contains functions for handling landing page creation.
  */
 
 use Drupal\Core\Link;
@@ -77,13 +77,11 @@ function nidirect_common_is_landing_page_with_theme_value(EntityInterface &$enti
  */
 function nidirect_common_get_redirect_url(string $source_path) {
   $redirect = \Drupal::service('redirect.repository')->findBySourcePath($source_path);
+  $redirect_url = '';
 
   if (!empty(($redirect))) {
     $redirect = array_pop($redirect);
     $redirect_url = $redirect->getRedirectUrl()->toString();
-  }
-  else {
-    $redirect_url = '';
   }
 
   return $redirect_url;

--- a/nidirect_common/inc/landing_page.redirects.inc
+++ b/nidirect_common/inc/landing_page.redirects.inc
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * @file
+ * Contains functions Layout Builder search indexing.
+ */
+
+use Drupal\Core\Link;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Language\Language;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\Core\Url;
+use Drupal\node\Entity\Node;
+use Drupal\redirect\Entity\Redirect;
+
+/**
+ * Validation handler for landing page node forms.
+ *
+ * Checks whether there is already a landing page associated with the theme selected.
+ *
+ * @param array $form
+ *   The form array.
+ * @param FormStateInterface $form_state
+ *   The form state collection.
+ * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+ * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+ */
+function nidirect_common_landing_page_form_validate(array &$form, FormStateInterface $form_state) {
+  $theme_selected = $form_state->getValue('field_subtheme')[0]['target_id'];
+
+  $query = \Drupal::entityTypeManager()->getStorage('node')->getQuery();
+  $result = $query->condition('type', 'landing_page', '=')
+    ->condition('field_subtheme', $theme_selected, '=')
+    ->execute();
+
+  if (!empty($result)) {
+    $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($theme_selected);
+    $form_state->setErrorByName('field_subtheme', t('There is already a landing page associated with \':term_name\'', [':term_name' => $term->label()]));
+  }
+}
+
+/**
+ * Utility function to re-use checks for landing page node with valid theme field selection.
+ *
+ * @param EntityInterface $entity
+ *   The entity to evaluate.
+ * @return bool
+ */
+function nidirect_common_is_landing_page_with_theme_value(EntityInterface &$entity) {
+  if ($entity instanceof Node == FALSE) {
+    return FALSE;
+  }
+
+  $has_subtheme_value = $entity->hasField('field_subtheme') && !empty($entity->get('field_subtheme')->getString());
+
+  // Chain logic conditions: if one condition fails any remaining checks are skipped and the expression returns FALSE.
+  return ($entity->bundle() == 'landing_page' && $has_subtheme_value);
+}
+
+/**
+ * Utility function to detect whether a redirect already exists, return a URL of the
+ * destination if it does.
+ *
+ * @param string $source_path
+ *   The source path.
+ * @return string
+ */
+function nidirect_common_redirect_exists(string $source_path) {
+  $redirect = \Drupal::service('redirect.repository')->findBySourcePath($source_path);
+
+  if (!empty(($redirect))) {
+    $redirect = array_pop($redirect);
+    $redirect_url = $redirect->getRedirectUrl()->toString();
+  }
+  else {
+    $redirect_url = '';
+  }
+
+  return $redirect_url;
+}
+
+/**
+ * Function to check:
+ * - Whether there is already a landing page node associated with the theme selected.
+ * - Create a redirect or warn user if there is already a landing page for this theme.
+ *
+ * @param EntityInterface $entity
+ *   The landing page node entity.
+ */
+function nidirect_common_create_landing_page_redirect(EntityInterface $entity) {
+  $subtheme_tid = $entity->get('field_subtheme')->getString();
+  $taxonomy_term_path = 'taxonomy/term/' . $subtheme_tid;
+  $redirect_url = nidirect_common_redirect_exists($taxonomy_term_path);
+
+  if (empty($redirect_url)) {
+    Redirect::create([
+      'redirect_source' => $taxonomy_term_path,
+      'redirect_redirect' => 'internal:/node/' . $entity->id(),
+      'language' => Language::LANGCODE_NOT_SPECIFIED,
+      'status_code' => '301',
+    ])->save();
+  }
+  else {
+    // Notify the user that a redirect could not be created.
+    \Drupal::messenger()->addWarning(t('A redirect from the theme taxonomy page to this content was not created,
+        because there are already one or more redirects used for the theme taxonomy page.'));
+
+    // Add a convenience link for users who can administer redirects.
+    if (\Drupal::currentUser()->hasPermission('administer redirects')) {
+      $link = Link::createFromRoute('review existing redirects', 'redirect.list', [], ['query' => ['text' => $taxonomy_term_path]])->toString();
+      \Drupal::messenger()->addWarning(new TranslatableMarkup("You can @link to remove any unwanted redirects.", ["@link" => $link]));
+    }
+  }
+}

--- a/nidirect_common/inc/landing_page.redirects.inc
+++ b/nidirect_common/inc/landing_page.redirects.inc
@@ -10,7 +10,6 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\Language;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
-use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
 use Drupal\redirect\Entity\Redirect;
 
@@ -21,7 +20,7 @@ use Drupal\redirect\Entity\Redirect;
  *
  * @param array $form
  *   The form array.
- * @param FormStateInterface $form_state
+ * @param \Drupal\Core\Form\FormStateInterface $form_state
  *   The form state collection.
  * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
  * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
@@ -36,16 +35,25 @@ function nidirect_common_landing_page_form_validate(array &$form, FormStateInter
 
   if (!empty($result)) {
     $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($theme_selected);
-    $form_state->setErrorByName('field_subtheme', t('There is already a landing page associated with \':term_name\'', [':term_name' => $term->label()]));
+    $node = \Drupal::entityTypeManager()->getStorage('node')->load(array_pop($result));
+    $link = Link::createFromRoute($node->label(), 'entity.node.edit_form', ['node' => $node->id()])->toRenderable();
+
+    $message = new TranslatableMarkup("There is already a landing page node (@landing_page) associated with '@term_name'", [
+      '@landing_page' => \Drupal::service('renderer')->render($link),
+      '@term_name' => $term->label()
+    ]);
+
+    $form_state->setErrorByName('field_subtheme', $message);
   }
 }
 
 /**
- * Utility function to re-use checks for landing page node with valid theme field selection.
+ * Function to re-use checks for landing page node with valid theme field selection.
  *
- * @param EntityInterface $entity
+ * @param \Drupal\Core\Entity\EntityInterface $entity
  *   The entity to evaluate.
  * @return bool
+ *   TRUE if it is a landing page with theme field value, otherwise FALSE.
  */
 function nidirect_common_is_landing_page_with_theme_value(EntityInterface &$entity) {
   if ($entity instanceof Node == FALSE) {
@@ -59,14 +67,15 @@ function nidirect_common_is_landing_page_with_theme_value(EntityInterface &$enti
 }
 
 /**
- * Utility function to detect whether a redirect already exists, return a URL of the
+ * Detect whether a redirect already exists, return a URL of the
  * destination if it does.
  *
  * @param string $source_path
  *   The source path.
  * @return string
+ *   Redirect URL if found, empty string if not.
  */
-function nidirect_common_redirect_exists(string $source_path) {
+function nidirect_common_get_redirect_url(string $source_path) {
   $redirect = \Drupal::service('redirect.repository')->findBySourcePath($source_path);
 
   if (!empty(($redirect))) {
@@ -85,13 +94,13 @@ function nidirect_common_redirect_exists(string $source_path) {
  * - Whether there is already a landing page node associated with the theme selected.
  * - Create a redirect or warn user if there is already a landing page for this theme.
  *
- * @param EntityInterface $entity
+ * @param \Drupal\Core\Entity\EntityInterface $entity
  *   The landing page node entity.
  */
 function nidirect_common_create_landing_page_redirect(EntityInterface $entity) {
   $subtheme_tid = $entity->get('field_subtheme')->getString();
   $taxonomy_term_path = 'taxonomy/term/' . $subtheme_tid;
-  $redirect_url = nidirect_common_redirect_exists($taxonomy_term_path);
+  $redirect_url = nidirect_common_get_redirect_url($taxonomy_term_path);
 
   if (empty($redirect_url)) {
     Redirect::create([
@@ -108,8 +117,13 @@ function nidirect_common_create_landing_page_redirect(EntityInterface $entity) {
 
     // Add a convenience link for users who can administer redirects.
     if (\Drupal::currentUser()->hasPermission('administer redirects')) {
-      $link = Link::createFromRoute('review existing redirects', 'redirect.list', [], ['query' => ['text' => $taxonomy_term_path]])->toString();
-      \Drupal::messenger()->addWarning(new TranslatableMarkup("You can @link to remove any unwanted redirects.", ["@link" => $link]));
+      $link = Link::createFromRoute('review existing redirects', 'redirect.list', [], [
+        'query' => ['text' => $taxonomy_term_path]
+      ])->toString();
+
+      \Drupal::messenger()->addWarning(new TranslatableMarkup(
+        "You can @link to remove any unwanted redirects.", ["@link" => $link])
+      );
     }
   }
 }

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -5,13 +5,14 @@
  * Contains nidirect_common.module.
  */
 
+include_once 'inc/landing_page.redirects.inc';
+
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\node\Entity\Node;
-use Drupal\redirect\Entity\Redirect;
 use Drupal\views\ViewExecutable;
 
 /**
@@ -99,20 +100,8 @@ function nidirect_common_entity_presave(EntityInterface $entity) {
 function nidirect_common_entity_insert(EntityInterface $entity) {
   // Create a redirect from the taxonomy term when a landing page is created
   // (as long as a subtheme has been selected).
-  if ($entity->getEntityTypeId() == 'node') {
-    if ($entity->getType() == 'landing_page') {
-      if ($entity->isPublished()) {
-        if ($entity->hasField('field_subtheme') && !empty($entity->get('field_subtheme')->getString())) {
-          $subtheme_tid = $entity->get('field_subtheme')->getString();
-          Redirect::create([
-            'redirect_source' => 'taxonomy/term/' . $subtheme_tid,
-            'redirect_redirect' => 'internal:/node/' . $entity->id(),
-            'language' => 'und',
-            'status_code' => '301',
-          ])->save();
-        }
-      }
-    }
+  if (nidirect_common_is_landing_page_with_theme_value($entity)) {
+    nidirect_common_create_landing_page_redirect($entity);
   }
 }
 
@@ -120,24 +109,10 @@ function nidirect_common_entity_insert(EntityInterface $entity) {
  * Implements hook_entity_update().
  */
 function nidirect_common_entity_update(EntityInterface $entity) {
-  // If landing page has been published, create the redirect
-  // from the taxonomy term.
-  if ($entity->getEntityTypeId() == 'node') {
-    if ($entity->getType() == 'landing_page') {
-      if ($entity->isPublished()) {
-        if (!$entity->original->isPublished()) {
-          if ($entity->hasField('field_subtheme') && !empty($entity->get('field_subtheme')->getString())) {
-            $subtheme_tid = $entity->get('field_subtheme')->getString();
-            Redirect::create([
-              'redirect_source' => 'taxonomy/term/' . $subtheme_tid,
-              'redirect_redirect' => 'internal:/node/' . $entity->id(),
-              'language' => 'und',
-              'status_code' => '301',
-            ])->save();
-          }
-        }
-      }
-    }
+  // Create a redirect from the taxonomy term when a landing page is created
+  // (as long as a subtheme has been selected).
+  if (nidirect_common_is_landing_page_with_theme_value($entity)) {
+    nidirect_common_create_landing_page_redirect($entity);
   }
 }
 
@@ -300,6 +275,9 @@ function nidirect_common_form_alter(&$form, FormStateInterface $form_state, $for
       $msg .= "As an example, if you select 'Motoring / Road Safety' here then when you visit the page at ";
       $msg .= "/information-and-services/motoring there will be a link to this page labelled 'Road Safety'.";
       $form['field_subtheme']['widget']['#description'] = t($msg);
+
+      // Add a validate handler to detect any duplicates.
+      $form['#validate'][] = 'nidirect_common_landing_page_form_validate';
     }
   }
 }

--- a/nidirect_gp/src/PostcodeExtractor.php
+++ b/nidirect_gp/src/PostcodeExtractor.php
@@ -49,7 +49,7 @@ class PostcodeExtractor {
    */
   public function getPostCode(string $text_to_match) {
     $matches = [];
-    preg_match_all('/' . $this->postcodeRegex . '/', $text_to_match, $matches);
+    preg_match_all('/' . $this->postcodeRegex . '/i', $text_to_match, $matches);
 
     return $matches[0];
   }


### PR DESCRIPTION
Two key things in this PR:

1. It aims to avoid creating redirects for new landing pages when they already exist.
2. It aims to warn editors when saving a new landing page whether another already exists for that theme value. That should ward off any duplicate content issues and, conversely, also reduce the likelihood of duplicate redirects being created.

There's a fair bit of refactoring to move a lot of code shared between entity insert + update into a separate .inc file for better readability.