### PR TITLE
Add functional JS test to check content type presence.

### DIFF
--- a/nidirect_common/tests/src/Nightwatch/Tests/contentTypeValidation.js
+++ b/nidirect_common/tests/src/Nightwatch/Tests/contentTypeValidation.js
@@ -1,0 +1,46 @@
+const fs = require('fs');
+var types = [];
+const configDir = '../../config/sync';
+
+module.exports = {
+  '@tags': [
+    'nidirect',
+    'nidirect_common',
+  ],
+
+  'Test whether content types found in config folder are present in the UI': browser => {
+    browser
+      .pause(9000, function () {
+        fs.readdirSync(configDir).forEach(file => {
+          if (match = file.match(/node.type.(\w+)/)) {
+            // Open a readstream to the file.
+            var content = fs.readFileSync(configDir + '/' + file, 'utf8');
+            // Convert the string with line breaks into an array to ease
+            // iteration/regex matching without having to work around single quotes
+            // or control characters nestled alongside the values we want to try and extract.
+            lines = content.split(/\n/);
+
+            for (var i = 0; i < lines.length; i++) {
+              // Drop single quotes as they make word matching/detection much harder.
+              lines[i] = lines[i].replace(/'/g,'');
+              matches = lines[i].match(/^name: (.+)/);
+
+              if (matches) {
+                types.push(matches[1]);
+              }
+            }
+          }
+        });
+
+        browser
+          .drupalLogin({name: process.env.TEST_USER, password: process.env.TEST_PASS})
+          .drupalRelativeURL('/admin/structure/types')
+          .waitForElementVisible('body', 1000)
+
+        for (var i = 0; i < types.length; i++) {
+          browser.expect.element('.region-content table tbody').text.to.contain(types[i]);
+        }
+      });
+  }
+
+};

--- a/nidirect_common/tests/src/Nightwatch/Tests/contentTypeValidation.js
+++ b/nidirect_common/tests/src/Nightwatch/Tests/contentTypeValidation.js
@@ -35,7 +35,7 @@ module.exports = {
         browser
           .drupalLogin({name: process.env.TEST_USER, password: process.env.TEST_PASS})
           .drupalRelativeURL('/admin/structure/types')
-          .waitForElementVisible('body', 1000)
+          .waitForElementVisible('body', 9000)
 
         for (var i = 0; i < types.length; i++) {
           browser.expect.element('.region-content table tbody').text.to.contain(types[i]);


### PR DESCRIPTION
- Past config import bugs (mostly from core) have meant partially
  created content types have been left 'dangling' with no means to
recreate or remove without a full reinstall.
- This check will, at the very least, allow us to detect this a little
  sooner if it does happen again.

This test will need connecting up with the Circle CI jobs/triggers to make this return any significant value. Otherwise, we're relying on devs to execute the tests which isn't a terribly reliable approach :)