### PR TITLE
Set a server-side class to aid with disabling entity browser widget

### DIFF
--- a/nidirect_common/js/view-media-entity-browser.js
+++ b/nidirect_common/js/view-media-entity-browser.js
@@ -13,7 +13,13 @@
     attach: function (context, settings) {
       // Initially set the Select button state to disabled as the user will
       // not have selected any media element.
-      var $select_button = $('.is-entity-browser-submit', context);
+      // NB: The 'inactive' class is set in nidirect_media.module so that
+      // we only disable the browser widget select button and not the
+      // inline entity form button for creating new entities. The class
+      // is set server-side because it's impractical to handle client-side due to
+      // very small differences in element properties. Far easier/more certain to use
+      // a distinct class that is always present or absent when this code executes.
+      var $select_button = $('.is-entity-browser-submit.inactive', context);
       $select_button.prop('disabled', true);
 
       $('.views-row', context).click(function () {

--- a/nidirect_media/nidirect_media.module
+++ b/nidirect_media/nidirect_media.module
@@ -124,3 +124,15 @@ function nidirect_media_field_widget_form_alter(&$element, FormStateInterface $f
     $element['#attached']['library'][] = 'nidirect_media/entity_browser_entity_reference';
   }
 }
+
+/**
+ * Implements hook_form_alter().
+ */
+function nidirect_media_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if ($form_id == 'entity_browser_media_entity_browser_form') {
+    // If this is not the inline entity form widget, add a CSS class to initially disable the 'Select' button.
+    if (empty($form['widget']['inline_entity_form'])) {
+      $form['widget']['actions']['submit']['#attributes']['class'][] = 'inactive';
+    }
+  }
+}


### PR DESCRIPTION
buttons

- Only want to disable the browser widget's button to avoid submitting
  empty selections.
- Without the indicator class, the inline entity form's save button also
  disables meaning you can't create new inline-content.