### PR TITLE
D8NID-476 Set dictionary language for suggestions

### DIFF
--- a/nidirect_search/nidirect_search.module
+++ b/nidirect_search/nidirect_search.module
@@ -52,7 +52,8 @@ function nidirect_search_preprocess_search_api_spellcheck_did_you_mean(&$variabl
  * This hook can be removed if/when non-local dev Solr config is more cooperative.
  */
 function nidirect_search_search_api_solr_query_alter(QueryInterface $solarium_query, SearchApiQueryInterface $query) {
-  if (\Drupal::config('config_split.config_split.local')->get('status') == TRUE) {
-    $solarium_query->getSpellcheck()->setDictionary(Language::LANGCODE_NOT_SPECIFIED);
-  }
+  $solarium_query->getSpellcheck()->setDictionary(Language::LANGCODE_NOT_SPECIFIED);
+//  if (\Drupal::config('config_split.config_split.local')->get('status') == TRUE) {
+//    $solarium_query->getSpellcheck()->setDictionary(Language::LANGCODE_NOT_SPECIFIED);
+//  }
 }

--- a/nidirect_search/nidirect_search.module
+++ b/nidirect_search/nidirect_search.module
@@ -53,7 +53,4 @@ function nidirect_search_preprocess_search_api_spellcheck_did_you_mean(&$variabl
  */
 function nidirect_search_search_api_solr_query_alter(QueryInterface $solarium_query, SearchApiQueryInterface $query) {
   $solarium_query->getSpellcheck()->setDictionary(Language::LANGCODE_NOT_SPECIFIED);
-//  if (\Drupal::config('config_split.config_split.local')->get('status') == TRUE) {
-//    $solarium_query->getSpellcheck()->setDictionary(Language::LANGCODE_NOT_SPECIFIED);
-//  }
 }


### PR DESCRIPTION
Unclear why the language undefined dictionary fills but the langcode 'en' does not. Either way, this small change ensures we can query one. They happen to contain the same contents anyhow (for now).