### PR TITLE
Move XML Solr config into module hook for runtime alterations

### DIFF
--- a/nidirect_search/nidirect_search.module
+++ b/nidirect_search/nidirect_search.module
@@ -52,5 +52,219 @@ function nidirect_search_preprocess_search_api_spellcheck_did_you_mean(&$variabl
  * This hook can be removed if/when non-local dev Solr config is more cooperative.
  */
 function nidirect_search_search_api_solr_query_alter(QueryInterface $solarium_query, SearchApiQueryInterface $query) {
+  $route_name = \Drupal::routeMatch()->getRouteName();
+  $query_id = ($route_name == 'nidirect_contacts.default') ? 'query_contacts_az' : 'query';
+  $search_term = \Drupal::requestStack()->getCurrentRequest()->get($query_id);
+  $elevation_ids = [];
+
   $solarium_query->getSpellcheck()->setDictionary(Language::LANGCODE_NOT_SPECIFIED);
+  $solarium_query->addParam('spellcheck.onlyMorePopular', FALSE);
+  $solarium_query->addParam('spellcheck.extendedResults', FALSE);
+  $solarium_query->addParam('spellcheck.count', 1);
+  $solarium_query->addParam('mm.autoRelax', TRUE);
+
+  if ($route_name == 'view.search.search_page') {
+    // General search config.
+    $solarium_query->addParam('defType', 'edismax');
+    $solarium_query->addParam('tie', '0.01');
+    $solarium_query->addParam('mm', '1&lt;60%');
+
+    // General elevations.
+    switch (strtolower($search_term)) {
+      case 'mot':
+        $elevation_ids[] = 'node/3839';
+
+        break;
+
+      case 'go on ni':
+        $elevation_ids[] = 'node/5182';
+        $elevation_ids[] = 'node/5087';
+        $elevation_ids[] = 'node/5495';
+
+        break;
+
+      case 'make the call':
+        $elevation_ids[] = 'node/5177';
+
+        break;
+
+      case 'access ni':
+        $elevation_ids[] = 'node/4007';
+        $elevation_ids[] = 'node/3861';
+        $elevation_ids[] = 'node/3859';
+
+        break;
+
+      case 'ancestry':
+        $elevation_ids[] = 'node/2005';
+        $elevation_ids[] = 'node/3319';
+
+        break;
+
+      case 'groni':
+        $elevation_ids[] = 'node/3438';
+        $elevation_ids[] = 'node/2041';
+        $elevation_ids[] = 'node/2014';
+
+        break;
+
+      case 'proni maps':
+        $elevation_ids[] = 'node/9474';
+        $elevation_ids[] = 'node/9475';
+
+        break;
+
+      case 'dog':
+        $elevation_ids[] = 'node/2416';
+
+        break;
+
+      case 'fishing license':
+        $elevation_ids[] = 'node/2231';
+        $elevation_ids[] = 'node/2263';
+
+        break;
+
+      case 'fishing license price':
+        $elevation_ids[] = 'node/10040';
+        $elevation_ids[] = 'node/10039';
+
+        break;
+
+      case 'fishing permit costs':
+        $elevation_ids[] = 'node/2235';
+
+        break;
+
+      case 'angling permit':
+        $elevation_ids[] = 'node/2263';
+        $elevation_ids[] = 'node/2231';
+
+        break;
+
+      case 'angling permit price':
+        $elevation_ids[] = 'node/2235';
+
+        break;
+
+      case 'angling license price':
+        $elevation_ids[] = 'node/10040';
+        $elevation_ids[] = 'node/10039';
+
+        break;
+
+      case 'voluntary work':
+        $elevation_ids[] = 'node/1463';
+        $elevation_ids[] = 'node/1970';
+        $elevation_ids[] = 'node/1961';
+
+        break;
+
+      case 'jobs':
+        $elevation_ids[] = 'node/1604';
+
+        break;
+
+      case 'central heating grants':
+        $elevation_ids[] = 'node/2979';
+
+        break;
+
+      case 'energy advisors':
+        $elevation_ids[] = 'node/2979';
+        $elevation_ids[] = 'node/7663';
+
+        break;
+
+      case 'grant for replacement windows':
+        $elevation_ids[] = 'node/2979';
+
+        break;
+
+      case 'grant loft insulation':
+        $elevation_ids[] = 'node/2979';
+
+        break;
+
+      case 'heating grants':
+        $elevation_ids[] = 'node/2979';
+
+        break;
+
+      case 'sustainable heating grants':
+        $elevation_ids[] = 'node/2979';
+
+        break;
+
+      case 'giant hogweed':
+        $elevation_ids[] = 'node/1826';
+
+        break;
+
+      case 'pollution in rivers':
+        $elevation_ids[] = 'node/973';
+        $elevation_ids[] = 'node/963';
+
+        break;
+
+      case 'suspected pollution':
+        $elevation_ids[] = 'node/963';
+
+        break;
+    }
+  }
+
+  // Contacts search refinements.
+  if ($route_name == 'nidirect_contacts.default' || $route_name == 'nidirect_contacts.letter') {
+    $query->setParseMode(\Drupal::service('plugin.manager.search_api.parse_mode')->createInstance('direct'));
+    $solarium_query->addParam('defType', 'edismax');
+    // Minimum must Match: match at least 2 terms or 60% of multiple terms.
+    $solarium_query->addParam('mm', '2&lt;67% 5&lt;50%');
+
+    // Contacts elevations.
+    switch (strtolower($search_term)) {
+      case 'access ni':
+        $elevation_ids[] = 'node/9925';
+
+        break;
+
+      case 'water board':
+        $elevation_ids[] = 'node/330';
+
+        break;
+
+      case 'tourism ni':
+        $elevation_ids[] = 'node/468';
+
+        break;
+
+      case 'transport ni':
+        $elevation_ids[] = 'node/3710';
+
+        break;
+
+      case 'roads service':
+        $elevation_ids[] = 'node/3710';
+
+        break;
+    }
+  }
+
+  // Add elevations to the query.
+  if (!empty($elevation_ids)) {
+    // Prefix/suffix our node ids with <hash>-<index_id>-entity:<entity_type>/<entity_id>:<langcode>.
+    $solr_hash = '17dthr';
+    $index_id = 'default_content';
+    $elevation_items = [];
+
+    foreach ($elevation_ids as $entity_ref) {
+      $elevation_items[] = sprintf('%s-%s-entity:%s:%s',
+        $solr_hash,
+        $index_id,
+        $entity_ref,
+        Language::LANGCODE_NOT_SPECIFIED);
+    }
+
+    $solarium_query->addParam('elevateIds', implode(',', $elevation_items));
+  }
 }


### PR DESCRIPTION
Moves most of the prior fixed, XML based values into a runtime query alter hook. Existing values are hard coded (for now) but could be changed to come from an admin settings form in future.