### PR TITLE
D8NID-628 Boost service priority to steal control back from views

### DIFF
--- a/nidirect_breadcrumbs/nidirect_breadcrumbs.services.yml
+++ b/nidirect_breadcrumbs/nidirect_breadcrumbs.services.yml
@@ -39,7 +39,7 @@ services:
     class: Drupal\nidirect_breadcrumbs\HealthConditionBreadcrumb
     arguments: ['@entity_type.manager']
     tags:
-      - { name: breadcrumb_builder }
+      - { name: breadcrumb_builder, priority: 5000 }
 
   nidirect_breadcrumbs.breadcrumb.news:
     class: Drupal\nidirect_breadcrumbs\NewsBreadcrumb


### PR DESCRIPTION
Looks like the breadcrumb handler class needed a boost to its priority. Without it, views tries to take over and we just need it to move aside in this instance.