### PR TITLE
D8NID-717 Set banner render array in correct page region

### DIFF
--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -583,7 +583,7 @@ function nidirect_common_preprocess_page(&$variables) {
     }
 
     if (!empty($banner_image)) {
-      $variables['banner_display'] = $banner_image->view('default');
+      $variables['page']['top_banner']['banner_display'] = $banner_image->view('default');
     }
   }
 }


### PR DESCRIPTION
Ensures it is rendered in the correct element of the page, respecting broader page container boundaries.