### PR TITLE
Take over some of linkit module's functionality

### DIFF
--- a/nidirect_common/nidirect_common.info.yml
+++ b/nidirect_common/nidirect_common.info.yml
@@ -6,3 +6,5 @@ package: 'NIDirect'
 dependencies:
   - drupal:help
   - drupal:block
+  - linkit
+  - media

--- a/nidirect_common/nidirect_common.services.yml
+++ b/nidirect_common/nidirect_common.services.yml
@@ -2,3 +2,8 @@ services:
   nidirect_common.invalidate_taxonomy_list_cache_tags:
     class: Drupal\nidirect_common\InvalidateTaxonomyListCacheTags
     arguments: ['@cache_tags.invalidator', '@entity_type.manager']
+
+  nidirect_common.route_subscriber:
+    class: Drupal\nidirect_common\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/nidirect_common/src/Controller/LinkitAutocompleteController.php
+++ b/nidirect_common/src/Controller/LinkitAutocompleteController.php
@@ -59,7 +59,7 @@ class LinkitAutocompleteController implements ContainerInjectionInterface {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('entity.manager')->getStorage('linkit_profile'),
+      $container->get('entity_type.manager')->getStorage('linkit_profile'),
       $container->get('linkit.result_manager')
     );
   }
@@ -79,7 +79,7 @@ class LinkitAutocompleteController implements ContainerInjectionInterface {
    */
   public function autocomplete(Request $request, string $linkit_profile_id) {
     $this->linkitProfile = $this->linkitProfileStorage->load($linkit_profile_id);
-    $string = Unicode::strtolower($request->query->get('q'));
+    $string = mb_strtolower($request->query->get('q'));
 
     $matches = $this->resultManager->getResults($this->linkitProfile, $string);
 

--- a/nidirect_common/src/Controller/LinkitAutocompleteController.php
+++ b/nidirect_common/src/Controller/LinkitAutocompleteController.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Drupal\nidirect_common\Controller;
+
+/**
+ * @file
+ * Contains \Drupal\nidirect_common\Controller\LinkitAutocompleteController.
+ *
+ * Overrides the linkit equivalent so we can wire up our custom result manager
+ * as a workaround for no preprocessing or service replacement options.
+ */
+
+use Drupal\Component\Utility\Unicode;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\nidirect_common\LinkitResultManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+class LinkitAutocompleteController implements ContainerInjectionInterface {
+
+  /**
+   * The linkit profile storage service.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $linkitProfileStorage;
+
+  /**
+   * The result manager.
+   *
+   * @var \Drupal\nidirect_common\LinkitResultManager
+   */
+  protected $resultManager;
+
+  /**
+   * The linkit profile.
+   *
+   * @var \Drupal\linkit\ProfileInterface
+   */
+  protected $linkitProfile;
+
+  /**
+   * Constructs a EntityAutocompleteController object.
+   *
+   * @param \Drupal\Core\Entity\EntityStorageInterface $linkit_profile_storage
+   *   The linkit profile storage service.
+   * @param \Drupal\nidirect_common\LinkitResultManager $resultManager
+   *   The result service.
+   */
+  public function __construct(EntityStorageInterface $linkit_profile_storage, LinkitResultManager $resultManager) {
+    $this->linkitProfileStorage = $linkit_profile_storage;
+    $this->resultManager = $resultManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity.manager')->getStorage('linkit_profile'),
+      $container->get('linkit.result_manager')
+    );
+  }
+
+  /**
+   * Menu callback for linkit search autocompletion.
+   *
+   * Like other autocomplete functions, this function inspects the 'q' query
+   * parameter for the string to use to search for suggestions.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   * @param string $linkit_profile_id
+   *   The linkit profile id.
+   * @return  \Symfony\Component\HttpFoundation\JsonResponse
+   *   A JSON response containing the autocomplete suggestions.
+   */
+  public function autocomplete(Request $request, string $linkit_profile_id) {
+    $this->linkitProfile = $this->linkitProfileStorage->load($linkit_profile_id);
+    $string = Unicode::strtolower($request->query->get('q'));
+
+    $matches = $this->resultManager->getResults($this->linkitProfile, $string);
+
+    $json_object = new \stdClass();
+    $json_object->matches = $matches;
+
+    return new JsonResponse($json_object);
+  }
+
+}

--- a/nidirect_common/src/LinkitResultManager.php
+++ b/nidirect_common/src/LinkitResultManager.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Drupal\nidirect_common;
+
+/**
+ * @file
+ * Contains \Drupal\linkit\ResultManager.
+ */
+
+use Drupal\Component\Utility\Html;
+use Drupal\Core\Url;
+use Drupal\linkit\ProfileInterface;
+
+/**
+ * Result service to handle autocomplete matcher results.
+ */
+class LinkitResultManager {
+
+  /**
+   * Gets the results.
+   *
+   * @param \Drupal\linkit\ProfileInterface $linkitProfile
+   *   The linkit profile.
+   * @param string $search_string
+   *   The string ro use in the matchers.
+   *
+   * @return array
+   *   An array of matches.
+   */
+  public function getResults(ProfileInterface $linkitProfile, string $search_string) {
+    $matches = [];
+
+    if (empty(trim($search_string))) {
+      return [
+        [
+          'title' => t('No content results'),
+          'description' => t('Please enter search terms')
+        ]
+      ];
+    }
+
+    // Special for link to front page.
+    if (strpos($search_string, 'front') !== FALSE) {
+      $matches[] = [
+        'title' => t('Front page'),
+        'description' => 'The front page for this site.',
+        'path' => Url::fromRoute('<front>')->toString(),
+        'group' => t('System'),
+      ];
+    }
+
+    foreach ($linkitProfile->getMatchers() as $plugin) {
+      $matches = array_merge($matches, $plugin->getMatches($search_string));
+    }
+
+    // Check for an e-mail address then return an e-mail match and create a
+    // mail-to link if appropriate.
+    if (filter_var($search_string, FILTER_VALIDATE_EMAIL)) {
+      $matches[] = [
+        'title' => t('E-mail @email', ['@email' => $search_string]),
+        'description' => t('Creates a mailto link for e-mail @email', ['@email' => $search_string]),
+        'path' => 'mailto:' . Html::escape($search_string),
+        'group' => t('E-mail'),
+      ];
+    }
+
+    // If there is still no matches, return a "no results" array.
+    if (empty($matches)) {
+      return [
+        [
+          'title' => t('No content results'),
+          'description' => t('There were no content results. Using the link provided as-is.'),
+        ]
+      ];
+    }
+
+    return $matches;
+  }
+
+}

--- a/nidirect_common/src/NidirectCommonServiceProvider.php
+++ b/nidirect_common/src/NidirectCommonServiceProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Drupal\nidirect_common;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+
+// @note: You only need Reference, if you want to change service arguments.
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * Modifies the linkit result manager service.
+ */
+class NidirectCommonServiceProvider extends ServiceProviderBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container) {
+    // Overrides linkit.result_manager class as return
+    // output cannot be preprocessed.
+    $definition = $container->getDefinition('linkit.result_manager');
+    $definition->setClass('Drupal\nidirect_common\LinkitResultManager');
+  }
+
+}

--- a/nidirect_common/src/Routing/RouteSubscriber.php
+++ b/nidirect_common/src/Routing/RouteSubscriber.php
@@ -13,8 +13,7 @@ class RouteSubscriber extends RouteSubscriberBase {
 
   /**
    * Override from base class to set lighter
-   * event priority; execute after taxonomy_access_fix
-   * RouteSubscriber callbacks.
+   * event priority than linkit module.
    *
    * See https://www.drupal.org/docs/8/creating-custom-modules/subscribe-to-and-dispatch-events#s-event-subscriber-priorities.
    *

--- a/nidirect_common/src/Routing/RouteSubscriber.php
+++ b/nidirect_common/src/Routing/RouteSubscriber.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\nidirect_common\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Drupal\Core\Routing\RoutingEvents;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to the dynamic route events.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * Override from base class to set lighter
+   * event priority; execute after taxonomy_access_fix
+   * RouteSubscriber callbacks.
+   *
+   * See https://www.drupal.org/docs/8/creating-custom-modules/subscribe-to-and-dispatch-events#s-event-subscriber-priorities.
+   *
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[RoutingEvents::ALTER] = ['onAlterRoutes', -100];
+    return $events;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    // Swap Linkit\AutocompleteController for nidirect_common\LinkitAutocompleteController
+    // so we can effectively manipulate the content of the responses due to lack of
+    // preprocess and interfaces.
+    if ($route = $collection->get('linkit.autocomplete')) {
+      $route->setDefaults(['_controller' => '\Drupal\nidirect_common\Controller\LinkitAutocompleteController::autocomplete']);
+    }
+  }
+
+}


### PR DESCRIPTION
- Required due to a lack of preprocess or easy override (via dependecy injection) of underlying service classes.

May be useful to split into an origins module if Unity requires it?