### PR TITLE
D8NID-764 news queue

### DIFF
--- a/nidirect_homepage/src/Plugin/Block/FeaturedContentBlock.php
+++ b/nidirect_homepage/src/Plugin/Block/FeaturedContentBlock.php
@@ -37,7 +37,7 @@ class FeaturedContentBlock extends BlockBase implements ContainerFactoryPluginIn
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity type manager service.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(array $configuration, string $plugin_id, array $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;
   }

--- a/nidirect_homepage/src/Plugin/Block/FeaturedContentBlock.php
+++ b/nidirect_homepage/src/Plugin/Block/FeaturedContentBlock.php
@@ -3,17 +3,13 @@
 namespace Drupal\nidirect_homepage\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\taxonomy\Entity\Term;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a block to show a single featured content list.
- *
- * TODO: This class will need refining to be more selective over which
- * featured_content_list node it renders. At present, only the homepage will
- * use an instance of this node type but if the same are needed across other
- * site locations, a taxonomy driven approach will likely be required to organise
- * and select them by.
  *
  * @Block(
  *  id = "featured_content",
@@ -23,19 +19,39 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class FeaturedContentBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
   /**
-   * Drupal\Core\Entity\EntityManagerInterface definition.
+   * Drupal\Core\Entity\EntityTypeManagerInterface definition.
    *
-   * @var \Drupal\Core\Entity\EntityManagerInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  protected $entityManager;
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a new featured content block.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param array $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entity_type_manager;
+  }
 
   /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    $instance = new static($configuration, $plugin_id, $plugin_definition);
-    $instance->entityManager = $container->get('entity.manager');
-    return $instance;
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager')
+    );
   }
 
   /**
@@ -44,16 +60,25 @@ class FeaturedContentBlock extends BlockBase implements ContainerFactoryPluginIn
   public function build() {
     $build = [];
 
-    // Load the first featured content list node.
-    $fcl_nodes = $this->entityManager->getStorage('node')->loadByProperties([
-      'type' => 'featured_content_list'
-    ]);
+    // Our featured content list will be tagged with the "Homepage" term, so load that term object.
+    $homepage_tag = $this->entityTypeManager
+      ->getStorage('taxonomy_term')
+      ->loadByProperties(['name' => 'Homepage']);
+    $homepage_tag = reset($homepage_tag);
 
-    if (!empty($fcl_nodes)) {
-      $node_render = $this->entityManager->getViewBuilder('node')->view(reset($fcl_nodes));
+    if ($homepage_tag instanceof Term) {
+      // Load the first featured content list node.
+      $fcl_nodes = $this->entityTypeManager->getStorage('node')->loadByProperties([
+        'type' => 'featured_content_list',
+        'field_tags' => $homepage_tag->id(),
+      ]);
 
-      $build['#theme'] = 'featured_content';
-      $build['featured_content'] = $node_render;
+      if (!empty($fcl_nodes)) {
+        $node_render = $this->entityTypeManager->getViewBuilder('node')->view(reset($fcl_nodes));
+
+        $build['#theme'] = 'featured_content';
+        $build['featured_content'] = $node_render;
+      }
     }
 
     return $build;

--- a/nidirect_news/src/Controller/NewsListingController.php
+++ b/nidirect_news/src/Controller/NewsListingController.php
@@ -3,6 +3,9 @@
 namespace Drupal\nidirect_news\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\taxonomy\TermInterface;
+use Drupal\views\ResultRow;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Block\BlockManagerInterface;
@@ -67,29 +70,73 @@ class NewsListingController extends ControllerBase {
   public function default() {
     $content = [];
 
+    // Empty page parameter means we're on the landing page for news.
     if (empty($this->requestStack->getCurrentRequest()->query->get('page'))) {
-      // Load/execute the view to extract the node ids; we add these as exclusions
-      // to the 'older news items' contextual args to avoid duplication between
-      // the two blocks and retain the 'sticky' flag ability to pin important
-      // items to the list of top four items.
-      $latest_news_view = $this->entityTypeManager()->getStorage('view')->load('news')->getExecutable();
-      $latest_news_view->setDisplay('latest_news');
+      // Featured news comes from the first featured content list node tagged with 'News'.
+      $featured_news_ids = [];
 
-      $latest_news_view->initHandlers();
-      $latest_news_view->preExecute();
-      $latest_news_view->execute();
-      $latest_news_view->buildRenderable('latest_news');
+      $news_tag = $this->entityTypeManager
+        ->getStorage('taxonomy_term')
+        ->loadByProperties(['name' => 'News']);
+      $news_tag = reset($news_tag);
 
-      $latest_news_nids = [];
+      if ($news_tag instanceof TermInterface && $news_tag->bundle() == 'tags') {
+        // If we've got a valid news tag from the tags vocab, go ahead and try to load
+        // the featured content list node tagged with it.
+        $featured_news_list = $this->entityTypeManager
+          ->getStorage('node')
+          ->loadByProperties([
+            'type' => 'featured_content_list',
+            'field_tags' => $news_tag->id(),
+          ]);
 
-      if (!empty($latest_news_view->result)) {
-        foreach ($latest_news_view->result as $row) {
-          $latest_news_nids[] = $row->nid;
+        if (!empty($featured_news_list)) {
+          $featured_news_list = reset($featured_news_list);
         }
-      }
 
-      // Latest news embed display.
-      $content['latest_news'] = $latest_news_view->render();
+        if (!empty($featured_news_list->field_featured_content)) {
+          $featured_content_values = $featured_news_list->field_featured_content->getValue();
+
+          if (!empty($featured_content_values)) {
+            $featured_news_ids = array_column($featured_content_values, 'target_id');
+          }
+        }
+
+        // Load/execute the view to extract the node ids; we add these as exclusions
+        // to the 'older news items' contextual args to avoid duplication between
+        // the two blocks and retain the 'sticky' flag ability to pin important
+        // items to the list of top four items.
+        $latest_news_view = $this->entityTypeManager()->getStorage('view')->load('news')->getExecutable();
+        $latest_news_view->setDisplay('latest_news');
+        $latest_news_view->initHandlers();
+        $latest_news_view->setArguments([implode(',', $featured_news_ids ?? [])]);
+        $latest_news_view->preExecute();
+        $latest_news_view->execute();
+        $latest_news_view->buildRenderable('latest_news');
+
+        // Views' SQL query will naturally order the rows by node id, ascending. It's not easy to introduce
+        // the original weightings into the SQL query from the featured content list field values without
+        // some kind of pseudo-table + join + order by clause. That's quite a lot of effort for such a
+        // small amount of data so you might as well re-order the result rows sequence right here.
+        $sorted_results = [];
+
+        // Nested loops could be more efficient with careful use of array_filter
+        // and anonymous/lamba functions within, but we should choose clarity over brevity.
+        foreach ($featured_news_ids as $id) {
+          foreach ($latest_news_view->result as $row) {
+            if ($row->nid == $id) {
+              $sorted_results[] = $row;
+              break;
+            }
+          }
+        }
+
+        // Replace the view results array with the sorted array.
+        $latest_news_view->result = $sorted_results;
+
+        // Create a render array that our controller can return/render.
+        $content['latest_news'] = $latest_news_view->render();
+      }
 
       // View title: see views_embed_view() which the render array relies on for details of why this is missing.
       $content['older_news_title'] = [
@@ -107,8 +154,11 @@ class NewsListingController extends ControllerBase {
       '#type' => 'view',
       '#name' => 'news',
       '#display_id' => 'older_news',
-      '#arguments' => [implode(',', $latest_news_nids ?? [])],
     ];
+
+    if (!empty($featured_news_ids)) {
+      $content['older_news']['#arguments'] = [implode(',', $featured_news_ids)];
+    }
 
     return $content;
   }


### PR DESCRIPTION
A PR that adjusts the news controller to:

- Replace the generic views render array for 'latest news' with something to load a featured content list tagged with a specific tag,
- take the node ids it provides and inject them into a modified views display as arguments.

So essentially only uses views to present the data so we don't need to modify the frontend, but rather than let it do the querying part we use contextual arguments to inject the things we want it to show based on our controller's data query.