### PR TITLE
D8 nid 662

### DIFF
--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -583,7 +583,11 @@ function nidirect_common_preprocess_page(&$variables) {
   }
 
   // Assign our banner image entity, either a node or a taxonomy term.
-  $entity = $variables['node'] ?? $variables['term'];
+  if (isset($variables['node'])) {
+    $entity = $variables['node'];
+  } elseif (isset($variables['term'])) {
+    $entity = $variables['term'];
+  }
 
   // Fetch and display the node or theme banner image and footer text.
   if (!empty($entity)) {

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -576,8 +576,8 @@ function nidirect_common_preprocess_page(&$variables) {
   // Apply link manager library to all non-admin pages.
   $variables['#attached']['library'][] = 'nidirect_common/link_manager';
 
-  // Sometimes $variables['node'] is not a node object, but just contains the nid as a string,
-  // so we'll avoid errors and allow for that here.
+  // Sometimes $variables['node'] is not a node object, but just contains the
+  // nid as a string, so we'll avoid errors and allow for that here.
   if (isset($variables['node']) && is_string($variables['node'])) {
     $variables['node'] = Node::load($variables['node']);
   }
@@ -585,7 +585,8 @@ function nidirect_common_preprocess_page(&$variables) {
   // Assign our banner image entity, either a node or a taxonomy term.
   if (isset($variables['node'])) {
     $entity = $variables['node'];
-  } elseif (isset($variables['term'])) {
+  }
+  elseif (isset($variables['term'])) {
     $entity = $variables['term'];
   }
 

--- a/nidirect_common/tests/src/Functional/DrivingInstructorTest.php
+++ b/nidirect_common/tests/src/Functional/DrivingInstructorTest.php
@@ -28,7 +28,7 @@ class DrivingInstructorTest extends BrowserTestBase {
 
   /**
    * Set to TRUE to strict check all configuration saved.
-   * TNeed to set to FALSE here because some contrib modules have a schema in
+   * Need to set to FALSE here because some contrib modules have a schema in
    * config/schema that does not match the actual settings exported
    * (eu_cookie_compliance and google_analytics_counter, I'm looking at you).
    *

--- a/nidirect_common/tests/src/Functional/DrivingInstructorTest.php
+++ b/nidirect_common/tests/src/Functional/DrivingInstructorTest.php
@@ -27,6 +27,18 @@ class DrivingInstructorTest extends BrowserTestBase {
   protected $profile = 'test_profile';
 
   /**
+   * Set to TRUE to strict check all configuration saved.
+   * This is needed because some contrib modules have a schema in config/schema that
+   * does not match the actual settings exported (eu_cookie_compliance and
+   * google_analytics_counter, I'm looking at you).
+   *
+   * @see \Drupal\Core\Config\Development\ConfigSchemaChecker
+   *
+   * @var bool
+   */
+  protected $strictConfigSchema = FALSE;
+
+  /**
    * Tests the behavior when creating the node.
    */
   public function testNodeCreate() {

--- a/nidirect_common/tests/src/Functional/DrivingInstructorTest.php
+++ b/nidirect_common/tests/src/Functional/DrivingInstructorTest.php
@@ -28,11 +28,10 @@ class DrivingInstructorTest extends BrowserTestBase {
 
   /**
    * Set to TRUE to strict check all configuration saved.
+   *
    * Need to set to FALSE here because some contrib modules have a schema in
    * config/schema that does not match the actual settings exported
    * (eu_cookie_compliance and google_analytics_counter, I'm looking at you).
-   *
-   * @see \Drupal\Core\Config\Development\ConfigSchemaChecker
    *
    * @var bool
    */

--- a/nidirect_common/tests/src/Functional/DrivingInstructorTest.php
+++ b/nidirect_common/tests/src/Functional/DrivingInstructorTest.php
@@ -28,9 +28,9 @@ class DrivingInstructorTest extends BrowserTestBase {
 
   /**
    * Set to TRUE to strict check all configuration saved.
-   * This is needed because some contrib modules have a schema in config/schema that
-   * does not match the actual settings exported (eu_cookie_compliance and
-   * google_analytics_counter, I'm looking at you).
+   * TNeed to set to FALSE here because some contrib modules have a schema in
+   * config/schema that does not match the actual settings exported
+   * (eu_cookie_compliance and google_analytics_counter, I'm looking at you).
    *
    * @see \Drupal\Core\Config\Development\ConfigSchemaChecker
    *

--- a/nidirect_common/tests/src/Functional/GPPracticeTest.php
+++ b/nidirect_common/tests/src/Functional/GPPracticeTest.php
@@ -32,8 +32,6 @@ class GPPracticeTest extends BrowserTestBase {
    * config/schema that does not match the actual settings exported
    * (eu_cookie_compliance and google_analytics_counter, I'm looking at you).
    *
-   * @see \Drupal\Core\Config\Development\ConfigSchemaChecker
-   *
    * @var bool
    */
   protected $strictConfigSchema = FALSE;

--- a/nidirect_common/tests/src/Functional/GPPracticeTest.php
+++ b/nidirect_common/tests/src/Functional/GPPracticeTest.php
@@ -28,7 +28,7 @@ class GPPracticeTest extends BrowserTestBase {
 
   /**
    * Set to TRUE to strict check all configuration saved.
-   * TNeed to set to FALSE here because some contrib modules have a schema in
+   * Need to set to FALSE here because some contrib modules have a schema in
    * config/schema that does not match the actual settings exported
    * (eu_cookie_compliance and google_analytics_counter, I'm looking at you).
    *

--- a/nidirect_common/tests/src/Functional/GPPracticeTest.php
+++ b/nidirect_common/tests/src/Functional/GPPracticeTest.php
@@ -27,6 +27,18 @@ class GPPracticeTest extends BrowserTestBase {
   protected $profile = 'test_profile';
 
   /**
+   * Set to TRUE to strict check all configuration saved.
+   * TNeed to set to FALSE here because some contrib modules have a schema in
+   * config/schema that does not match the actual settings exported
+   * (eu_cookie_compliance and google_analytics_counter, I'm looking at you).
+   *
+   * @see \Drupal\Core\Config\Development\ConfigSchemaChecker
+   *
+   * @var bool
+   */
+  protected $strictConfigSchema = FALSE;
+
+  /**
    * Tests the behavior when creating the node with two fields.
    */
   public function testVanillaNodeCreate() {


### PR DESCRIPTION
Turn off strict schema checking so that PHPUnit tests can run.
This is necessary because some contrib modules (like eu_cookie_compliance and google_analytics_counter) export config that doesn't match their defined schema.

Also fix 'undefined index' bug in preprocess function.