### PR TITLE
D8NID-812 Only swap render array on news FCL node, not homepage.

### DIFF
--- a/nidirect_news/nidirect_news.module
+++ b/nidirect_news/nidirect_news.module
@@ -35,10 +35,21 @@ function nidirect_news_preprocess_field(array &$variables) {
  * Implements hook_preprocess_node().
  */
 function nidirect_news_preprocess_node(array &$variables) {
-  if ($variables['node']->getType() == 'featured_content_list' && $variables['view_mode'] == 'full') {
-    // Replace the node view with a rendered view display, using the node items as arguments.
-    // This mirrors the display you would see on the embedded views display.
-    $variables['content'] = \Drupal::service('nidirect_news.news')->getFeaturedNews();
+  if ($variables['node']->getType() != 'featured_content_list') {
+    return;
+  }
+
+  if ($variables['view_mode'] == 'full' && !empty($variables['node']->field_tags->target_id)) {
+    $news_tag = \Drupal::entityTypeManager()
+      ->getStorage('taxonomy_term')
+      ->loadByProperties(['name' => 'News']);
+    $news_tag = reset($news_tag);
+
+    if ($variables['node']->field_tags->target_id == $news_tag->id()) {
+      // Replace the node view with a rendered view display, using the node items as arguments.
+      // This mirrors the display you would see on the embedded views display.
+      $variables['content'] = \Drupal::service('nidirect_news.news')->getFeaturedNews();
+    }
   }
 }
 

--- a/nidirect_news/tests/src/Nightwatch/Tests/featuredContentListViewSwitch.js
+++ b/nidirect_news/tests/src/Nightwatch/Tests/featuredContentListViewSwitch.js
@@ -1,0 +1,37 @@
+let newsContentTitles = [];
+let homepageFeaturedTitles = [];
+
+module.exports = {
+  '@tags': ['regression'],
+
+  before: browser => {
+    // Gather the titles of the current 'latest/featured news' content.
+    browser.drupalRelativeURL('/news');
+    browser.elements('css selector', '.card .card__title', function (result) {
+      for (let item in result.value) {
+        browser.elementIdText(result.value[item].ELEMENT, function (result) {
+          newsContentTitles.push(result.value);
+        });
+      }
+    });
+
+    // Gather the titles of the current featured items on the homepage.
+    browser.drupalRelativeURL('/');
+    browser.elements('css selector', '.card--featured .card__title', function (result) {
+      for (let item in result.value) {
+        browser.elementIdText(result.value[item].ELEMENT, function (result) {
+          homepageFeaturedTitles.push(result.value);
+        });
+      }
+    });
+  },
+
+  '[Regression] D8NID-812: ensure featured content list render array switch for news does not affect homepage': browser => {
+    // Check if the two arrays match, or not.
+    console.log('Featured news items: ' + newsContentTitles.join(', '));
+    console.log('Homepage featured content items: ' + homepageFeaturedTitles.join(', '));
+
+    browser.assert.notEqual(newsContentTitles, homepageFeaturedTitles, 'Featured news items and featured homepage items should not match');
+  }
+
+};


### PR DESCRIPTION
Also adds a regression test to detect anything like it in future.