### PR TITLE
D8NID-719 Change label on shs default value to match regular dropdown options

### DIFF
--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -322,8 +322,7 @@ function nidirect_common_form_node_form_alter(&$form, FormStateInterface $form_s
   }
 
   if (array_key_exists('field_top_level_theme', $form)) {
-
-    // Can't use a hidden input tqype on a container element or
+    // Can't use a hidden input type on a container element or
     // set #access to FALSE as we need the form_state values,
     // so using the .hidden class to hide from the user.
     $form['field_top_level_theme']['#attributes']['class'][] = 'hidden';
@@ -418,6 +417,15 @@ function validate_date_field(&$form_state, $date_field) {
       }
     }
   }
+}
+
+/**
+ * Implements hook_field_widget_WIDGET_TYPE_form_alter().
+ */
+function nidirect_common_field_widget_options_shs_form_alter(&$element, FormStateInterface $form_state, $context) {
+  // Replace default of "- Select a value -" to be "- None -".
+  $element['#options']['_none'] = '- ' . t('None') . ' -';
+  $element['#shs']['settings']['anyLabel'] = '- ' . t('None') . ' -';
 }
 
 /**


### PR DESCRIPTION
Well this threw me down the garden path. There are a range of hooks allowing you to adjust the SHS widget's options and, at face value, it seems to only show get methods on the widget object making it hard to set a new value in the way it would expect.

However, because the widget object type is a translated markup object, I'm proposing to cheat a little here and replace the value with a translated text value. As far as I can tell, it seems like a safe operation.