### PR TITLE
Output 'Older news items' heading on initial news landing page only.

### DIFF
--- a/nidirect_news/src/Controller/NewsListingController.php
+++ b/nidirect_news/src/Controller/NewsListingController.php
@@ -184,7 +184,7 @@ class NewsListingController extends ControllerBase {
         '#value' => t('Older news items'),
       ];
     }
-    
+
     // Older news.
     $content['older_news'] = [
       '#type' => 'view',

--- a/nidirect_news/src/Controller/NewsListingController.php
+++ b/nidirect_news/src/Controller/NewsListingController.php
@@ -184,9 +184,7 @@ class NewsListingController extends ControllerBase {
         '#value' => t('Older news items'),
       ];
     }
-
-
-
+    
     // Older news.
     $content['older_news'] = [
       '#type' => 'view',

--- a/nidirect_news/src/Controller/NewsListingController.php
+++ b/nidirect_news/src/Controller/NewsListingController.php
@@ -172,18 +172,20 @@ class NewsListingController extends ControllerBase {
     // Empty page parameter means we're on the landing page for news.
     if (empty($this->requestStack->getCurrentRequest()->query->get('page'))) {
       $content['latest_news'] = $this->getFeaturedNews();
+
+      // View title: see views_embed_view() which the render array relies on for
+      // details of why this is missing.
+      $content['older_news_title'] = [
+        '#type' => 'html_tag',
+        '#tag' => 'h2',
+        '#attributes' => [
+          'class' => 'hr-above',
+        ],
+        '#value' => t('Older news items'),
+      ];
     }
 
-    // View title: see views_embed_view() which the render array relies on for
-    // details of why this is missing.
-    $content['older_news_title'] = [
-      '#type' => 'html_tag',
-      '#tag' => 'h2',
-      '#attributes' => [
-        'class' => 'hr-above',
-      ],
-      '#value' => t('Older news items'),
-    ];
+
 
     // Older news.
     $content['older_news'] = [


### PR DESCRIPTION
Ensures the "Older news items" title is only output on the first page of news.