### PR TITLE
Health conditions search prompt

### DIFF
--- a/nidirect_health_conditions/css/search-conditions-prompt.css
+++ b/nidirect_health_conditions/css/search-conditions-prompt.css
@@ -1,0 +1,74 @@
+.search-conditions-prompt {
+  display: block;
+  position: fixed;
+  left: 0;
+  bottom: 50px
+}
+
+.search-conditions-prompt a {
+  display: block;
+  position: absolute;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  clip: rect(1px,1px,1px,1px);
+  box-sizing: border-box;
+  line-height: 50px;
+  padding: 0;
+  color: #fff !important;
+  background-color: rgba(1, 100, 188, 0.9);
+  text-decoration: none !important;
+  text-align: center;
+  z-index: 2;
+  white-space: nowrap;
+  opacity: 0;
+  -webkit-transition: opacity .3s 0s,visibility 0s .3s;
+  -moz-transition: opacity .3s 0s,visibility 0s .3s;
+  transition: opacity .3s 0s,visibility 0s .3s
+}
+
+.search-conditions-prompt a:before {
+  content: " ";
+  display: inline-block;
+  width: 48px;
+  height: 50px;
+  vertical-align: middle;
+  background: transparent url("data:image/svg+xml;charset=utf-8,%3Csvg%20id%3D%22Layer_1%22%20data-name%3D%22Layer%201%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20100%20100%22%20width%3D%22100px%22%20height%3D%22100px%22%20preserveAspectRatio%3D%22xMinYMid%22%3E%3Cdefs%3E%3Cstyle%3E.cls-1%7Bfill%3A%23fff%3Bfill-rule%3Aevenodd%3B%7D%3C%2Fstyle%3E%3C%2Fdefs%3E%3Ctitle%3Esearch-icon%3C%2Ftitle%3E%3Cpath%20class%3D%22cls-1%22%20d%3D%22M97.5%2C77.89a6%2C6%2C0%2C0%2C1-8.25%2C1.49L64.89%2C62.65a5.85%2C5.85%2C0%2C0%2C1-2.55-5A21.59%2C21.59%2C0%2C0%2C1%2C25.4%2C46.81a21.16%2C21.16%2C0%2C0%2C1%2C3.47-16%2C21.69%2C21.69%2C0%2C0%2C1%2C30-5.42%2C21.36%2C21.36%2C0%2C0%2C1%2C7.1%2C27%2C6%2C6%2C0%2C0%2C1%2C5.67.58L96%2C69.71A5.86%2C5.86%2C0%2C0%2C1%2C97.5%2C77.89ZM61.38%2C40.3a14.8%2C14.8%2C0%2C0%2C0-6.23-9.6%2C15.12%2C15.12%2C0%2C0%2C0-20.92%2C3.77A14.88%2C14.88%2C0%2C0%2C0%2C38%2C55.24%2C15.12%2C15.12%2C0%2C0%2C0%2C59%2C51.46%2C14.74%2C14.74%2C0%2C0%2C0%2C61.38%2C40.3Z%22%2F%3E%3C%2Fsvg%3E") left center no-repeat;
+  background-size: auto 40px
+}
+
+.search-conditions-prompt a:after {
+  content: " ";
+  display: inline-block;
+  width: 27px;
+  height: 50px;
+  vertical-align: middle;
+  background: transparent url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAAPCAQAAAC7b6xuAAAAsUlEQVR4AY3LQ2KEURSFwbOU2LbNcTQMd5s1xLaNL7i/0a9rXpJYYpNSOdHINhuSmOcT2KfCERo4B75ZFeeYQ6odwVyIUZ4wx9TmhPogPDAoiUEeMKfUFwyPDMrQzx3mnOZUOEsEQw+3mEvaFKAuEoYURwfXmGs6gnCKebKQQBuXmFt6JGojYVjZaOEcc8eKMxgaOIOAhREVRi0nsTAqN6q5doQ0pnjhL4yreMxylBd+ABWdFyV4bCZyAAAAAElFTkSuQmCC") right center no-repeat;
+  background-size: 17px auto
+}
+
+.search-conditions-prompt a:active,
+.search-conditions-prompt a:focus,
+.search-conditions-prompt a.scp-is-visible {
+  position: fixed;
+  width: 100%;
+  height: 50px;
+  clip: auto;
+  overflow: auto;
+  opacity: 1;
+  -webkit-transition: opacity .3s 0s,visibility 0s 0s;
+  -moz-transition: opacity .3s 0s,visibility 0s 0s;
+  transition: opacity .3s 0s,visibility 0s 0s
+}
+
+.search-conditions-prompt a:active,
+.search-conditions-prompt a:focus {
+  background-color: #0165b4;
+  color: #fff
+}
+
+@media (min-width: 768px) {
+  .search-conditions-prompt {
+    display: none;
+  }
+}

--- a/nidirect_health_conditions/js/search-conditions-prompt.js
+++ b/nidirect_health_conditions/js/search-conditions-prompt.js
@@ -1,0 +1,52 @@
+/**
+ * @file
+ * Defines Javascript behaviors for search conditions prompt.  The prompt is a link which skips user down
+ * to the health conditions search widget which appears at the bottom of health conditions on narrow screens.
+ */
+
+(function ($, Drupal) {
+  Drupal.behaviors.searchConditionsPrompt = {
+    attach: function attach (context) {
+
+      const $hc_search_widget = $('#block-exposedformhealth-conditionssearch-sidebar-2');
+
+      // Add scp (search conditions prompt) if health-conditions-az-widget is present.
+      if ($hc_search_widget.length) {
+
+        // First, add the jump link container
+        $('h1').after('<div class="search-conditions-prompt"><a href="#edit-query-health-az">Search for health conditions</a></div>');
+
+        // Browser window scroll (in pixels) after which the prompt is displayed.
+        const scp_offset = $('h1').offset().top + 54,
+          // Duration of the top scrolling animation (in ms).
+          scp_scroll_top_duration = 700,
+          // Grab the prompt link.
+          $scp = $('.search-conditions-prompt > a'),
+          // Browser window scroll (in pixels) after which the prompt is hidden (when search/az widget is in view).
+          scp_offset_hide = $hc_search_widget.offset().top - $(window).height() + $scp.height();
+
+        // Hide or show the scp.
+        $(window).scroll(function () {
+          if ($(this).scrollTop() > scp_offset && $(this).scrollTop() < scp_offset_hide) {
+            $scp.addClass('scp-is-visible');
+          } else {
+            $scp.removeClass('scp-is-visible scp-fade-out');
+          }
+        });
+
+        // Smooth scroll to scp.
+        $scp.on('mousedown', function (event) {
+          event.preventDefault();
+          $('body,html').animate({
+              scrollTop: $hc_search_widget.offset().top,
+            }, scp_scroll_top_duration,
+            function () {
+              // animation complete
+              $('#edit-query-health-az').focus();
+            }
+          );
+        });
+      }
+    }
+  };
+}(jQuery, Drupal));

--- a/nidirect_health_conditions/nidirect_health_conditions.libraries.yml
+++ b/nidirect_health_conditions/nidirect_health_conditions.libraries.yml
@@ -1,0 +1,9 @@
+search_conditions_prompt:
+  js:
+    js/search-conditions-prompt.js: {}
+  css:
+    component:
+      css/search-conditions-prompt.css: {}
+  dependencies:
+    - core/drupal
+    - core/jquery

--- a/nidirect_health_conditions/nidirect_health_conditions.module
+++ b/nidirect_health_conditions/nidirect_health_conditions.module
@@ -227,3 +227,12 @@ function nidirect_health_conditions_inline_entity_form_entity_form_alter(array &
     hide($entity_form['field_parent_condition']);
   }
 }
+
+/**
+ * Implements hook_preprocess_node().
+ */
+function nidirect_health_conditions_preprocess_node(array &$variables) {
+  if ($variables['node']->getType() === 'health_condition') {
+    $variables['#attached']['library'][] = 'nidirect_health_conditions/search_conditions_prompt';
+  }
+}


### PR DESCRIPTION
Adds JS/CSS to the health conditions module to display the "search conditions prompt" when viewing health conditions on a narrow screen.  

The prompt appears at the bottom of the screen after scrolling down a bit.  Clicking the prompt skips you down to the search/a-z widget at the bottom of the page and sets focus on the search input.

<img width="373" alt="Screenshot 2020-09-24 at 13 42 06" src="https://user-images.githubusercontent.com/52457988/94147451-31495000-fe6d-11ea-8b55-a95e2ab07f7d.png">
