### PR TITLE
D8 nid 154 health conditions az

### DIFF
--- a/nidirect_health_conditions/nidirect_health_conditions.module
+++ b/nidirect_health_conditions/nidirect_health_conditions.module
@@ -74,8 +74,8 @@ function nidirect_health_conditions_views_pre_render(ViewExecutable $view) {
 
     // Generate the header content to show N condition(s)
     // matching 'search term'.
-    $single_message = "@count condition under @search_term";
-    $plural_message = "@count conditions under @search_term";
+    $single_message = "@count condition";
+    $plural_message = "@count conditions";
   }
 
   if (empty($search_term) || $view->total_rows == 0) {

--- a/nidirect_health_conditions/nidirect_health_conditions.routing.yml
+++ b/nidirect_health_conditions/nidirect_health_conditions.routing.yml
@@ -3,7 +3,7 @@ nidirect_health_conditions.letter:
   path: '/services/health-conditions-a-z/letter/{letter}'
   defaults:
     _controller: '\Drupal\nidirect_health_conditions\Controller\HealthConditionsListingController::filterByLetter'
-    _title_callback: '\Drupal\nidirect_health_conditions\Controller\HealthConditionsListingController::getTitle'
+    _title: 'Health conditions A to Z'
     route_type: health_conditions_letter
   requirements:
     _permission: 'access content'

--- a/nidirect_health_conditions/src/Controller/HealthConditionsListingController.php
+++ b/nidirect_health_conditions/src/Controller/HealthConditionsListingController.php
@@ -56,24 +56,6 @@ class HealthConditionsListingController extends ControllerBase {
   }
 
   /**
-   * Controller callback for the page title.
-   *
-   * Use this to examine route parameters/any other conditions
-   * and vary the string that is returned.
-   *
-   * @return string
-   *   The page title.
-   */
-  public function getTitle(string $route_type) {
-    if ($route_type == 'health_conditions_letter') {
-      // A letter has been selected from the A-Z.
-      $letter = \Drupal::routeMatch()->getParameter('letter');
-      return t('Health conditions under :letter', [':letter' => strtoupper($letter)]);
-    }
-    return t('Health conditions A to Z');
-  }
-
-  /**
    * Content when filtered by letter.
    *
    * @return array


### PR DESCRIPTION
Removes page title callback and some header massaging from health conditions module.  Using hook_preprocess_page_title in the theme to add bits and pieces of helpful information - see https://github.com/dof-dss/nicsdru_nidirect_theme/pull/159