### PR TITLE
Add home link to breadcrumb if there are ancestor terms to show 

### DIFF
--- a/nidirect_breadcrumbs/src/TaxonomyTermThemesBreadcrumb.php
+++ b/nidirect_breadcrumbs/src/TaxonomyTermThemesBreadcrumb.php
@@ -80,9 +80,10 @@ class TaxonomyTermThemesBreadcrumb implements BreadcrumbBuilderInterface {
     // Remove the current term from the list.
     array_shift($ancestors);
 
-    $links[] = Link::createFromRoute(t('Home'), '<front>');
-
     if (!empty($ancestors)) {
+      
+      $links[] = Link::createFromRoute(t('Home'), '<front>');
+
       $terms = (count($ancestors) > 1) ? array_reverse($ancestors, TRUE) : $ancestors;
 
       foreach ($terms as $term) {

--- a/nidirect_breadcrumbs/src/TaxonomyTermThemesBreadcrumb.php
+++ b/nidirect_breadcrumbs/src/TaxonomyTermThemesBreadcrumb.php
@@ -81,7 +81,7 @@ class TaxonomyTermThemesBreadcrumb implements BreadcrumbBuilderInterface {
     array_shift($ancestors);
 
     if (!empty($ancestors)) {
-      
+
       $links[] = Link::createFromRoute(t('Home'), '<front>');
 
       $terms = (count($ancestors) > 1) ? array_reverse($ancestors, TRUE) : $ancestors;


### PR DESCRIPTION
Prevent breadcrumb showing just a home link.