### PR TITLE
D8 nid 842

### DIFF
--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -440,10 +440,10 @@ function _retrieve_hierarchical_field(EntityInterface $entity, string $field) {
  * Implements hook_form_BASE_FORM_ID_alter().
  */
 function nidirect_common_form_system_performance_settings_alter(&$form, FormStateInterface $form_state, $form_id) {
-  // Alter the system performance admin screen so that a 'Browser and proxy cache maximum age'
-  // of 1 year may be selected.
+  // Alter the system performance admin screen so that a 'Browser and proxy
+  // cache maximum age' of 1 year may be selected.
   // Also add an informative suffix to make it clear that this has been done.
   $form['caching']['page_cache_maximum_age']['#options'][31536000] = t("1 year");
   $form['caching']['page_cache_maximum_age']['#suffix'] = t("<i>@suffix</i>",
-    array('@suffix' => "Note that Drupal core settings have been customised here for NIDirect to allow for a maximum age of 1 year"));
+    ['@suffix' => "Note that Drupal core settings have been customised here for NIDirect to allow for a maximum age of 1 year"]);
 }

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -435,3 +435,17 @@ function _retrieve_hierarchical_field(EntityInterface $entity, string $field) {
 
   return $field_value;
 }
+
+/**
+ * Implements hook_form_alter().
+ */
+function nidirect_common_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Alter the system performance admin screen so that a 'Browser and proxy cache maximum age'
+  // of 1 year may be selected.
+  // Also add an informative suffix to make it clear that this has been done.
+  if ($form_id == 'system_performance_settings') {
+    $form['caching']['page_cache_maximum_age']['#options'][31536000] = t("1 year");
+    $form['caching']['page_cache_maximum_age']['#suffix'] = t("<i>@suffix</i>",
+      array('@suffix' => "Note that Drupal core settings have been customised here for NIDirect to allow for a maximum age of 1 year"));
+  }
+}

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -437,15 +437,13 @@ function _retrieve_hierarchical_field(EntityInterface $entity, string $field) {
 }
 
 /**
- * Implements hook_form_alter().
+ * Implements hook_form_BASE_FORM_ID_alter().
  */
-function nidirect_common_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+function nidirect_common_form_system_performance_settings_alter(&$form, FormStateInterface $form_state, $form_id) {
   // Alter the system performance admin screen so that a 'Browser and proxy cache maximum age'
   // of 1 year may be selected.
   // Also add an informative suffix to make it clear that this has been done.
-  if ($form_id == 'system_performance_settings') {
-    $form['caching']['page_cache_maximum_age']['#options'][31536000] = t("1 year");
-    $form['caching']['page_cache_maximum_age']['#suffix'] = t("<i>@suffix</i>",
-      array('@suffix' => "Note that Drupal core settings have been customised here for NIDirect to allow for a maximum age of 1 year"));
-  }
+  $form['caching']['page_cache_maximum_age']['#options'][31536000] = t("1 year");
+  $form['caching']['page_cache_maximum_age']['#suffix'] = t("<i>@suffix</i>",
+    array('@suffix' => "Note that Drupal core settings have been customised here for NIDirect to allow for a maximum age of 1 year"));
 }


### PR DESCRIPTION
Alter the system performance admin screen so that a 'Browser and proxy cache maximum age' of 1 year may be selected.
Also add an informative suffix to make it clear that this has been done.

Related to https://github.com/dof-dss/nidirect-drupal/pull/465