### PR TITLE
Instruct clientside_validation module not to operate on non-webform forms

### DIFF
--- a/nidirect_common/inc/form_alter.inc
+++ b/nidirect_common/inc/form_alter.inc
@@ -56,20 +56,6 @@ function nidirect_common_inline_entity_form_entity_form_alter(&$entity_form, &$f
 }
 
 /**
- * Implements hook_form_media_alter().
- */
-function nidirect_common_form_media_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  // Turn off client-side validation on media base forms.
-  if (!empty($form['#after_build'])) {
-    foreach ($form['#after_build'] as $key => $value) {
-      if ($value == 'clientside_validation_form_after_build') {
-        unset($form['#after_build'][$key]);
-      }
-    }
-  }
-}
-
-/**
  * Implements hook_form_BASE_FORM_ID_alter().
  */
 function nidirect_common_form_taxonomy_term_form_alter(&$form, FormStateInterface $form_state, $form_id) {
@@ -144,16 +130,6 @@ function nidirect_common_form_node_form_alter(&$form, FormStateInterface $form_s
       $field_toc_enable_description = t(
         'Enable to display a list of quick links to Heading 2s on the page.'
       );
-    }
-  }
-
-  // Turn off client-side validation on node base forms;
-  // it breaks entity browser preview widgets.
-  if (!empty($form['#after_build'])) {
-    foreach ($form['#after_build'] as $key => $value) {
-      if ($value == 'clientside_validation_form_after_build') {
-        unset($form['#after_build'][$key]);
-      }
     }
   }
 

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -207,27 +207,6 @@ function nidirect_common_taxonomy_term_presave(EntityInterface $entity) {
 }
 
 /**
- * Implements hook_page_attachments_alter().
- */
-function nidirect_common_page_attachments_alter(array &$attachments) {
-  // Turn off clientside_validation on selected routes. Usually due to
-  // interference with other AJAX related features, eg: Media Library.
-  $routes = [
-    'entity.node.edit_form',
-    'entity.media.edit_form',
-    'node.add',
-    'media.add',
-    'layout_builder.overrides.node.view',
-  ];
-
-  if (in_array(\Drupal::routeMatch()->getRouteName(), $routes)) {
-    // 1 == Yes, 2 == No.
-    // See ClientsideValidationjQuerySettingsForm::buildForm().
-    $attachments['#attached']['drupalSettings']['clientside_validation_jquery']['validate_all_ajax_forms'] = 2;
-  }
-}
-
-/**
  * Form validation handler for publication dates.
  */
 function nidirect_common_validate_publication_date(&$form, FormStateInterface $form_state) {

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -237,7 +237,8 @@ function nidirect_common_validate_publication_date(&$form, FormStateInterface $f
   // Clear the form errors.
   $form_state->clearErrors();
 
-  $date_fields = ['field_published_date',
+  $date_fields = [
+    'field_published_date',
     'field_last_review_date',
     'field_next_review_date',
     'field_cwp_payments_period',
@@ -434,4 +435,16 @@ function _retrieve_hierarchical_field(EntityInterface $entity, string $field) {
   }
 
   return $field_value;
+}
+
+/**
+ * Implements hook_clientside_validation_should_validate().
+ */
+function nidirect_common_clientside_validation_should_validate($element, FormStateInterface &$form_state, $form_id) {
+  // Turn off clientside validation jquery functionality on anything that isn't a webform form.
+  // Also see: nidirect_common_page_attachments_alter. nidirect_common_form_BASE_FORM_ID_alter hooks
+  // where similar adjustments have been needed to work around clientside_validation module.
+  if (!preg_match('/^webform_/', $form_id)) {
+    return FALSE;
+  }
 }

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -428,7 +428,7 @@ function nidirect_common_clientside_validation_should_validate($element, FormSta
   }
 }
 
-  /**
+/**
  * Implements hook_form_BASE_FORM_ID_alter().
  */
 function nidirect_common_form_system_performance_settings_alter(&$form, FormStateInterface $form_state, $form_id) {

--- a/nidirect_common/tests/src/Nightwatch/Tests/regressions/layoutBuilder.js
+++ b/nidirect_common/tests/src/Nightwatch/Tests/regressions/layoutBuilder.js
@@ -26,12 +26,14 @@ module.exports = {
       .click('input#edit-submit');
 
     // Should now be on the node display page. Open the sidebar.
-    browser.click('.moderation-sidebar-toolbar-tab.toolbar-tab > a');
+    browser.pause(2000).click('.moderation-sidebar-toolbar-tab.toolbar-tab > a');
 
     // Click the Layout button link. We're selecting by order of button appearance;
     // would be better to find some way of reading the link text value instead.
-    browser.expect.element('.moderation-sidebar-secondary-tasks > a:nth-child(3)').text.to.equal('Layout');
-    browser.click('.moderation-sidebar-secondary-tasks > a:nth-child(3)');
+    browser.useXpath().click("//*[@class=\"moderation-sidebar-secondary-tasks\"]//a[text()='Layout']");
+
+    // Swap back to CSS selectors.
+    browser.useCss();
 
     // Now at /node/NID/layout, need to add a section.
     browser.click('#layout-builder a.layout-builder__link--add');


### PR DESCRIPTION
A little more dancing around this module. It's not practical to target a multitude of form ids and routes, so inverting this and only letting it act on webform forms seems more pragmatic.

It seems to still need two hooks at the very least, but the `#after_build` removal is something from before that can probably stay for now even though it might not be needed with the page_attachments_alter and this hook in place,.