### PR TITLE
D8NID-822 Wrap featured news embed into a block

### DIFF
--- a/nidirect_news/nidirect_news.module
+++ b/nidirect_news/nidirect_news.module
@@ -7,7 +7,6 @@
 
 use Drupal\Core\Link;
 use Drupal\Core\Url;
-use Drupal\node\NodeInterface;
 use Drupal\taxonomy\TermInterface;
 use Drupal\views\ViewExecutable;
 
@@ -100,25 +99,5 @@ function nidirect_news_views_pre_render(ViewExecutable $view) {
         }
       }
     }
-  }
-}
-
-/**
- * Implements hook_views_pre_build().
- */
-function nidirect_news_views_pre_build(ViewExecutable $view) {
-  if ($view->id() == 'news' && $view->current_display == 'featured_news_block') {
-    $featured_news_ids = \Drupal::service('nidirect_news.news')->getFeaturedNewsIds();
-
-    // If we're on a news node page, exclude the currently viewed node.
-    $node = \Drupal::routeMatch()->getParameter('node');
-
-    if ($node instanceof NodeInterface) {
-      // Need array_search to return the index of the item to unset, because
-      // unset($key) alone won't check the value, just the array index value.
-      unset($featured_news_ids[array_search($node->id(), $featured_news_ids)]);
-    }
-
-    $view->setArguments([implode(',', $featured_news_ids ?? [])]);
   }
 }

--- a/nidirect_news/src/Plugin/Block/FeaturedNewsBlock.php
+++ b/nidirect_news/src/Plugin/Block/FeaturedNewsBlock.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Drupal\nidirect_news\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+
+/**
+ * Block for presenting featured news; wrapper around FCL node tagged with 'News'.
+ *
+ * @Block(
+ *  id = "featured_news_block",
+ *  admin_label = @Translation("Featured news"),
+ * )
+ */
+class FeaturedNewsBlock extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    $content['featured_news'] = \Drupal::service('nidirect_news.news')->getNewsEmbed('featured_news');
+    return $content;
+  }
+
+}


### PR DESCRIPTION
Re-use as much of the broader news views display approach as possible. Essentially use views as a rendering method for news node ids passed in as contextual arguments. Featured news display differs from the 'latest news' one on the landing page because it uses fields (like the block display) for the sidebar