### PR TITLE
D8NID-910 Also hide address field if it only contains a country value

### DIFF
--- a/nidirect_contacts/nidirect_contacts.module
+++ b/nidirect_contacts/nidirect_contacts.module
@@ -129,5 +129,6 @@ function nidirect_contacts_preprocess_node(&$variables) {
 
   if ($has_value == FALSE) {
     hide($field_location);
+    hide($field_address);
   }
 }


### PR DESCRIPTION
Spotted during testing: `contacts/jobs-benefits-offices` - a sneaky 'United Kingdom' value is rendered because the address field only contains the default country value, isn't empty and then renders to the page.

Now treating it with the same rules as the location field for consistency.