### PR TITLE
Fix for incorrectly referenced array in sidebar buttons

### DIFF
--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -328,8 +328,8 @@ function nidirect_common_moderation_sidebar_alter(&$build, &$context) {
     }
 
     // Strip AJAX class to link direct to page.
-    if (!empty($build['actions']['version_history']['#attributes']['class'])) {
-      $build['actions']['secondary']['version_history']['#attributes']['class'] = array_diff($build['actions']['version_history']['#attributes']['class'], ['use-ajax']);
+    if (!empty($build['actions']['secondary']['version_history']['#attributes']['class'])) {
+      $build['actions']['secondary']['version_history']['#attributes']['class'] = array_diff($build['actions']['secondary']['version_history']['#attributes']['class'], ['use-ajax']);
     }
   }
 


### PR DESCRIPTION
Surprised this worked before but perhaps there has been a shift in the underlying render array. In any case, this correctly references the array segments allowing the extra CSS class to be pruned off allowing the revisions to be viewed on their own page.