### PR TITLE
D8NID-989 Extra check on array element before attempting to access method on it

### DIFF
--- a/nidirect_contacts/nidirect_contacts.module
+++ b/nidirect_contacts/nidirect_contacts.module
@@ -117,6 +117,10 @@ function nidirect_contacts_preprocess_node(&$variables) {
     return;
   }
 
+  if (empty($field_address[0]['#address_format'])) {
+    return;
+  }
+
   $required_fields = $field_address[0]['#address_format']->getRequiredFields();
 
   // If the address field values don't have any of the required field values, hide the location field.


### PR DESCRIPTION
May also fix D8NID-991. Slightly tricky issue whereby `getRequiredFields()` may sometimes be null, so adding an extra check in this PR to try and avoid calling that function unless we're sure the address config is not empty.