### PR TITLE
D8NID-996: Adjust media edit dialog route title and add button to canonical form

### DIFF
--- a/nidirect_common/inc/form_alter.inc
+++ b/nidirect_common/inc/form_alter.inc
@@ -7,6 +7,7 @@
 
 use Drupal\Component\Utility\NestedArray;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\media\MediaInterface;
 use Nette\Utils\Arrays;
 
 /**
@@ -297,4 +298,33 @@ function nidirect_common_field_widget_telephone_plus_widget_form_alter(&$element
       ':input[name="field_telephone[' . $context['delta'] . '][telephone_predefined]"]' => ['value' => 'Other'],
     ],
   ];
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Minor adjustments to the media dialog form, inspired by the
+ * patch at https://www.drupal.org/project/drupal/issues/3168868,
+ * so we can distinguish between editing and overridding alt/alignment
+ * properties (from core) and another button to take you to the canonical
+ * media form to allow editors to edit any canonical custom field values.
+ */
+function nidirect_common_form_editor_media_dialog_alter(array &$form, FormStateInterface $form_state) {
+  $media_embed_element = $form_state->get('media_embed_element');
+  $media = \Drupal::service('entity.repository')->loadEntityByUuid('media', $media_embed_element['data-entity-uuid']);
+
+  if ($media instanceof MediaInterface === FALSE) {
+    return;
+  }
+
+  $form['actions']['edit_media_link']['#markup'] = $media->toLink(
+    t('Edit all media fields'),
+    'edit-form',
+    [
+      'attributes' => [
+        'class' => 'button',
+        'target' => '_blank',
+      ]
+    ]
+  )->toString();
 }

--- a/nidirect_common/inc/form_alter.inc
+++ b/nidirect_common/inc/form_alter.inc
@@ -317,6 +317,19 @@ function nidirect_common_form_editor_media_dialog_alter(array &$form, FormStateI
     return;
   }
 
+  $form['guidance_label'] = [
+    '#type' => 'label',
+    '#title' => 'Overriding media options',
+    '#weight' => -100,
+  ];
+  $form['guidance'] = [
+    '#type' => 'html_tag',
+    '#tag' => 'p',
+    '#value' => t("The options presented are allow you to override some of the options for this media item
+      when it is embedded in other content. To replace the image, or alter other field values, please use the
+      'Edit all media fields' button (opens in a new tab/window)"),
+    '#weight' => -99,
+  ];
   $form['actions']['edit_media_link']['#markup'] = $media->toLink(
     t('Edit all media fields'),
     'edit-form',

--- a/nidirect_common/nidirect_common.services.yml
+++ b/nidirect_common/nidirect_common.services.yml
@@ -4,3 +4,7 @@ services:
     arguments: ['@cache_tags.invalidator', '@entity_type.manager']
   linkit.suggestion_manager:
     class: Drupal\nidirect_common\LinkitSuggestionManager
+  nidirect_common.route_subscriber:
+    class: Drupal\nidirect_common\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/nidirect_common/src/Routing/RouteSubscriber.php
+++ b/nidirect_common/src/Routing/RouteSubscriber.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Drupal\nidirect_common\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to the dynamic route events.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    /*
+     * Adjust the form title to make it clear we're only offering basic media
+     * attributes here and for the full edit options, the editor needs to open
+     * the full canonical entity form using the button provided (see
+     * nidirect_common/inc/form_alter.inc for details); based on a patch
+     * found at https://www.drupal.org/project/drupal/issues/3168868).
+     *
+     * See https://www.drupal.org/project/drupal/issues/3132324 for background
+     * as to the UX issues around presenting the full entity form in the modal,
+     * plus ongoing discussion in core. See '\Drupal\media\Form\EditorMediaDialog'
+     * for the implementation of that form and its AJAX handling, which is fairly
+     * tricky to modify and adapt to present and handle extra fields.
+     */
+    if ($route = $collection->get('editor.media_dialog')) {
+      $route->setDefault('_title', 'Override media properties');
+    }
+  }
+
+}


### PR DESCRIPTION
See JIRA ticket for full context. TL;DR: provides editors option to edit media fields via button on the ckeditor modal form. Also tweaks the wording to make it clear the ckeditor is for overriding any canonical field values.