### PR TITLE
Slight re-think on handling parent HC nodes.

### DIFF
--- a/nidirect_health_conditions/nidirect_health_conditions.module
+++ b/nidirect_health_conditions/nidirect_health_conditions.module
@@ -32,14 +32,18 @@ function nidirect_health_conditions_node_view(array &$build, EntityInterface $en
   }
 
   if ($entity->bundle() == 'health_condition_alternative' && $view_mode == 'search_result') {
-    // We want to render the referenced health condition's search_result node
-    // contents but replace its title with the title from this
-    // health_condition_alternative node. This ensures we can introduce
-    // duplicates of a certain health condition, with a custom title, without
-    // having to intricately preprocess various parts of the views display.
-    $build['field_parent_condition'][0]['#node']->setTitle($entity->getTitle());
-    // Hide the original health_condition_alternative node title.
-    $build['title']['#access'] = FALSE;
+    // Inject the parent condition's summary text into the render array
+    // and hide the parent condition node so it doesn't render in itself.
+    $hc_node = &$build['field_parent_condition'][0]['#node'];
+
+    if ($hc_node instanceof NodeInterface &&
+      $hc_node->bundle() == 'health_condition' &&
+        $hc_node->isPublished()) {
+
+      // Use of $view_mode ensures we get the appropriate field config.
+      $build['field_summary'] = $hc_node->field_summary->view($view_mode);
+      $build['field_parent_condition']['#access'] = FALSE;
+    }
   }
 }
 


### PR DESCRIPTION
Problems with adjusting the node title of the parent node meant it was
easier to drop in a search_result view mode template for the HCA node
and just focus on adding the summary value from the HC node into the
render array. Keeps things simpler!