### PR TITLE
Turn off JS from link-manager.js on facet links

### DIFF
--- a/nidirect_driving_instructors/nidirect_driving_instructors.module
+++ b/nidirect_driving_instructors/nidirect_driving_instructors.module
@@ -207,3 +207,17 @@ function nidirect_driving_instructors_views_pre_render(ViewExecutable $view) {
     }
   }
 }
+
+/**
+ * Implements hook_preprocess_facets_item_list().
+ */
+function nidirect_driving_instructors_preprocess_facets_item_list(array &$variables) {
+  // Turn off JS from nidirect_common/link-manager.js which would otherwise break the facet links.
+  if (empty($variables['items'])) {
+    return;
+  }
+
+  foreach ($variables['items'] as $key => &$facet) {
+    $facet['value']['#attributes']['data-self-ref'] = 'false';
+  }
+}


### PR DESCRIPTION
Without this, the facet link is stripped leaving text alone which is not useful to the end-user