### PR TITLE
hide article teaser listing fields on node edit form

### DIFF
--- a/nidirect_landing_pages/nidirect_landing_pages.module
+++ b/nidirect_landing_pages/nidirect_landing_pages.module
@@ -93,6 +93,11 @@ function nidirect_landing_pages_form_alter(&$form, FormStateInterface $form_stat
   if ($form_id === 'layout_builder_add_block' || $form_id === 'layout_builder_update_block') {
     $form['settings']['label_display']['#access'] = FALSE;
   }
+  // Hide the listing fields as they may now only be edited in layout builder.
+  if (($form_id == 'node_landing_page_form') || ($form_id == 'node_landing_page_edit_form')) {
+    $form['field_manually_control_listing']['#access'] = FALSE;
+    $form['field_listing']['#access'] = FALSE;
+  }
 }
 
 /**


### PR DESCRIPTION
Do not show the 'manually control listing' checkbox or the listing fields when editing or creating a landing page node. This functionality is now available in layout builder only.