### PR TITLE
Driving instructors search mods

### DIFF
--- a/nidirect_driving_instructors/nidirect_driving_instructors.module
+++ b/nidirect_driving_instructors/nidirect_driving_instructors.module
@@ -90,11 +90,11 @@ function nidirect_driving_instructors_form_alter(&$form, &$form_state, &$form_id
     $form['actions']['#weight'] = 3;
     $form['f[0]']['#weight'] = 4;
 
-    // Hide help and category radios on results page.
+    // Remove help and category radios on results page.
     $inputs = $form_state->getUserInput();
     if (!empty($inputs['search_api_fulltext'])) {
       unset($form['help']);
-      $form['f[0]']['#type'] = 'hidden';
+      unset($form['f[0]']);
     }
   }
 


### PR DESCRIPTION
Quick bug fix - remove category radios altogether from the search results page instead of outputting as a hidden input.  The hidden input leads to broken pager links due to the addition of an extra query parameter f[0]=categories:all.