### PR TITLE
D8NID-1094 Cold Weather Payment checker validation fixes

### DIFF
--- a/nidirect_cold_weather_payments/src/Form/ColdWeatherPaymentCheckerForm.php
+++ b/nidirect_cold_weather_payments/src/Form/ColdWeatherPaymentCheckerForm.php
@@ -208,9 +208,9 @@ class ColdWeatherPaymentCheckerForm extends FormBase {
    */
   protected function validatePostcode(array &$form, FormStateInterface $form_state) {
     if (preg_match('/^BT[0-9]{1,2}( ?[0-9][A-Z]{2})?$/i', $form_state->getValue('postcode'))) {
-      return true;
+      return TRUE;
     }
-    return false;
+    return FALSE;
   }
 
   /**

--- a/nidirect_cold_weather_payments/src/Form/ColdWeatherPaymentCheckerForm.php
+++ b/nidirect_cold_weather_payments/src/Form/ColdWeatherPaymentCheckerForm.php
@@ -142,7 +142,7 @@ class ColdWeatherPaymentCheckerForm extends FormBase {
     $response = new AjaxResponse();
 
     // Set error message if postcode does not validate.
-    if (!$this->isValidNIPostcode($form, $form_state)) {
+    if (!$this->isValidNiPostcode($form, $form_state)) {
       $content = '<strong class="error">' . t('Postcode must be a valid Northern Ireland postcode.') . '</strong>';
       $response->addCommand(
         new HtmlCommand('#edit-postcode-error-message', $content)
@@ -206,7 +206,7 @@ class ColdWeatherPaymentCheckerForm extends FormBase {
   /**
    * Validates that a postcode is a valid NI postcode or outward code (first half of the postcode).
    */
-  protected function isValidNIPostcode(array &$form, FormStateInterface $form_state) {
+  protected function isValidNiPostcode(array &$form, FormStateInterface $form_state) {
     return preg_match('/^BT[0-9]{1,2}( ?[0-9][A-Z]{2})?$/i', $form_state->getValue('postcode'));
   }
 
@@ -223,7 +223,7 @@ class ColdWeatherPaymentCheckerForm extends FormBase {
       '#suffix' => '</p>',
     ];
 
-    if (!$this->isValidNIPostcode($form, $form_state)) {
+    if (!$this->isValidNiPostcode($form, $form_state)) {
       $error['#markup'] = $this->t('Postcode must be a valid Northern Ireland postcode');
       $output = $this->renderer->render($error);
     }

--- a/nidirect_cold_weather_payments/src/Form/ColdWeatherPaymentCheckerForm.php
+++ b/nidirect_cold_weather_payments/src/Form/ColdWeatherPaymentCheckerForm.php
@@ -142,7 +142,7 @@ class ColdWeatherPaymentCheckerForm extends FormBase {
     $response = new AjaxResponse();
 
     // Set error message if postcode does not validate.
-    if (!$this->validatePostcode($form, $form_state)) {
+    if (!$this->isValidNIPostcode($form, $form_state)) {
       $content = '<strong class="error">' . t('Postcode must be a valid Northern Ireland postcode.') . '</strong>';
       $response->addCommand(
         new HtmlCommand('#edit-postcode-error-message', $content)
@@ -206,11 +206,8 @@ class ColdWeatherPaymentCheckerForm extends FormBase {
   /**
    * Validates that a postcode is a valid NI postcode or outward code (first half of the postcode).
    */
-  protected function validatePostcode(array &$form, FormStateInterface $form_state) {
-    if (preg_match('/^BT[0-9]{1,2}( ?[0-9][A-Z]{2})?$/i', $form_state->getValue('postcode'))) {
-      return TRUE;
-    }
-    return FALSE;
+  protected function isValidNIPostcode(array &$form, FormStateInterface $form_state) {
+    return preg_match('/^BT[0-9]{1,2}( ?[0-9][A-Z]{2})?$/i', $form_state->getValue('postcode'));
   }
 
   /**
@@ -226,7 +223,7 @@ class ColdWeatherPaymentCheckerForm extends FormBase {
       '#suffix' => '</p>',
     ];
 
-    if (!$this->validatePostcode($form, $form_state)) {
+    if (!$this->isValidNIPostcode($form, $form_state)) {
       $error['#markup'] = $this->t('Postcode must be a valid Northern Ireland postcode');
       $output = $this->renderer->render($error);
     }

--- a/nidirect_cold_weather_payments/src/Form/ColdWeatherPaymentCheckerForm.php
+++ b/nidirect_cold_weather_payments/src/Form/ColdWeatherPaymentCheckerForm.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\nidirect_cold_weather_payments\Form;
 
+use Drupal\Core\Ajax\RemoveCommand;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -148,11 +149,16 @@ class ColdWeatherPaymentCheckerForm extends FormBase {
       $response->addCommand(
         new InvokeCommand('#edit-postcode', 'addClass', ['error'])
       );
-      $response->addCommand(
-        new InvokeCommand('#edit-postcode', 'focus')
-      );
 
       return $response;
+    }
+    else {
+      $response->addCommand(
+        new InvokeCommand('#edit-postcode', 'removeClass', ['error'])
+      );
+      $response->addCommand(
+        new RemoveCommand('#edit-postcode-error-message .error')
+      );
     }
 
     $data = $this->cwpLookup($postcode_district);
@@ -184,7 +190,7 @@ class ColdWeatherPaymentCheckerForm extends FormBase {
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
     parent::validateForm($form, $form_state);
-
+    /*
     // Adding this validation to take care of older browsers.
     $postcode = $form_state->getValue('postcode');
 
@@ -195,6 +201,7 @@ class ColdWeatherPaymentCheckerForm extends FormBase {
         $form_state->setErrorByName('postcode', $this->t('Postcode must be a valid Northern Ireland postcode.'));
       }
     }
+    */
   }
 
   /**
@@ -222,6 +229,8 @@ class ColdWeatherPaymentCheckerForm extends FormBase {
 
     $form_state->set('message', $output);
     $form_state->setRebuild(TRUE);
+
+    parent::validateForm($form, $form_state);
   }
 
   /**


### PR DESCRIPTION
Fixes the following issues with the cold weather payment checker form:
- when entering an invalid postcode, the resulting error message would persist even after re-submitting the form with a valid postcode
- after triggering an error on the form and then refreshing the page (or even browsing to another page), an error message would be shown at the top of the page