### PR TITLE
Layout builder custom blocks - re-enable display title checkbox

### DIFF
--- a/nidirect_landing_pages/nidirect_landing_pages.module
+++ b/nidirect_landing_pages/nidirect_landing_pages.module
@@ -102,7 +102,7 @@ function nidirect_landing_pages_form_alter(&$form, FormStateInterface $form_stat
    *   $form['settings']['label_display']['#default_value'] = TRUE;
    *   $form['settings']['label_display']['#access'] = FALSE;
    * }
-  */
+   */
 
   // Hide the listing fields as they may now only be edited in layout builder.
   if (($form_id == 'node_landing_page_form') || ($form_id == 'node_landing_page_edit_form')) {

--- a/nidirect_landing_pages/nidirect_landing_pages.module
+++ b/nidirect_landing_pages/nidirect_landing_pages.module
@@ -98,10 +98,10 @@ function nidirect_landing_pages_form_alter(&$form, FormStateInterface $form_stat
   // Unfortunately it is not easy to target specific custom block types where we do want to hide this checkbox.
   // See https://www.drupal.org/project/drupal/issues/3028391.
   /*
-  if ($form_id === 'layout_builder_add_block' || $form_id === 'layout_builder_update_block') {
-    $form['settings']['label_display']['#default_value'] = TRUE;
-    $form['settings']['label_display']['#access'] = FALSE;
-  }
+   * if ($form_id === 'layout_builder_add_block' || $form_id === 'layout_builder_update_block') {
+   *   $form['settings']['label_display']['#default_value'] = TRUE;
+   *   $form['settings']['label_display']['#access'] = FALSE;
+   * }
   */
 
   // Hide the listing fields as they may now only be edited in layout builder.

--- a/nidirect_landing_pages/nidirect_landing_pages.module
+++ b/nidirect_landing_pages/nidirect_landing_pages.module
@@ -96,7 +96,10 @@ function nidirect_landing_pages_form_alter(&$form, FormStateInterface $form_stat
   // Hide the display title checkbox on the inline block form.
   if ($form_id === 'layout_builder_add_block' || $form_id === 'layout_builder_update_block') {
     $form['settings']['label_display']['#default_value'] = TRUE;
-    $form['settings']['label_display']['#access'] = FALSE;
+    // Commenting this out for now - there are some blocks where users need control over title display.
+    // Unfortunately it is not easy to target specific custom block types where we do want to hide this checkbox.
+    // See https://www.drupal.org/project/drupal/issues/3028391.
+    //$form['settings']['label_display']['#access'] = FALSE;
   }
 
   // Hide the listing fields as they may now only be edited in layout builder.

--- a/nidirect_landing_pages/nidirect_landing_pages.module
+++ b/nidirect_landing_pages/nidirect_landing_pages.module
@@ -99,7 +99,7 @@ function nidirect_landing_pages_form_alter(&$form, FormStateInterface $form_stat
     // Commenting this out for now - there are some blocks where users need control over title display.
     // Unfortunately it is not easy to target specific custom block types where we do want to hide this checkbox.
     // See https://www.drupal.org/project/drupal/issues/3028391.
-    // $form['settings']['label_display']['#access'] = FALSE;
+    /* $form['settings']['label_display']['#access'] = FALSE; */
   }
 
   // Hide the listing fields as they may now only be edited in layout builder.

--- a/nidirect_landing_pages/nidirect_landing_pages.module
+++ b/nidirect_landing_pages/nidirect_landing_pages.module
@@ -99,7 +99,7 @@ function nidirect_landing_pages_form_alter(&$form, FormStateInterface $form_stat
     // Commenting this out for now - there are some blocks where users need control over title display.
     // Unfortunately it is not easy to target specific custom block types where we do want to hide this checkbox.
     // See https://www.drupal.org/project/drupal/issues/3028391.
-    //$form['settings']['label_display']['#access'] = FALSE;
+    // $form['settings']['label_display']['#access'] = FALSE;
   }
 
   // Hide the listing fields as they may now only be edited in layout builder.

--- a/nidirect_landing_pages/nidirect_landing_pages.module
+++ b/nidirect_landing_pages/nidirect_landing_pages.module
@@ -94,13 +94,15 @@ function nidirect_landing_pages_form_alter(&$form, FormStateInterface $form_stat
   }
 
   // Hide the display title checkbox on the inline block form.
+  // Commenting this out for now - there are some blocks where users need control over title display.
+  // Unfortunately it is not easy to target specific custom block types where we do want to hide this checkbox.
+  // See https://www.drupal.org/project/drupal/issues/3028391.
+  /*
   if ($form_id === 'layout_builder_add_block' || $form_id === 'layout_builder_update_block') {
     $form['settings']['label_display']['#default_value'] = TRUE;
-    // Commenting this out for now - there are some blocks where users need control over title display.
-    // Unfortunately it is not easy to target specific custom block types where we do want to hide this checkbox.
-    // See https://www.drupal.org/project/drupal/issues/3028391.
-    /* $form['settings']['label_display']['#access'] = FALSE; */
+    $form['settings']['label_display']['#access'] = FALSE;
   }
+  */
 
   // Hide the listing fields as they may now only be edited in layout builder.
   if (($form_id == 'node_landing_page_form') || ($form_id == 'node_landing_page_edit_form')) {


### PR DESCRIPTION
For some custom blocks like accordions and video and caption, users need control over displaying the block title.  So we can't have this option hidden.  It would be nice to hide it for certain types of block (like cards where the title should always be visible) - but this is difficult to do (see https://www.drupal.org/project/drupal/issues/3028391).  So we are forced to make the option available for all blocks.