### PR TITLE
Use block config instead of taxonomy tags for referenced FCL nodes

### DIFF
--- a/nidirect_common/src/LinkitSuggestionManager.php
+++ b/nidirect_common/src/LinkitSuggestionManager.php
@@ -37,7 +37,7 @@ class LinkitSuggestionManager extends SuggestionManager {
   /**
    * {@inheritdoc}
    */
-  public function getSuggestions(ProfileInterface $linkitProfile, string $search_string) {
+  public function getSuggestions(ProfileInterface $linkitProfile, $search_string) {
 
     $suggestions = new SuggestionCollection();
 

--- a/nidirect_homepage/src/Plugin/Block/FeaturedContentBlock.php
+++ b/nidirect_homepage/src/Plugin/Block/FeaturedContentBlock.php
@@ -76,6 +76,7 @@ class FeaturedContentBlock extends BlockBase implements ContainerFactoryPluginIn
       }
     }
 
+    $build['#attributes']['class'] = ['section--featured-highlights'];
     return $build;
   }
 


### PR DESCRIPTION
There's a fair bit going on there but in summary:

- Adds block form + submit handlers to define options for FCL nodes to reference, and a way to store them in config.
- Looks up the config values when building the block, rather than using taxonomy terms from the tags vocab.

Full disclaimer: relies on FCL nodes to exist to work. Migrations/shifting IDs may cause some headaches here unless we can keep block config up to date after each migration run.