### PR TITLE
Translation help block

### DIFF
--- a/nidirect_common/js/application-links-notranslate.js
+++ b/nidirect_common/js/application-links-notranslate.js
@@ -1,0 +1,27 @@
+/**
+ * @file
+ * Defines Javascript fix to prevent Google Translate altering application green button links.
+ */
+(function ($) {
+
+  "use strict";
+
+  Drupal.behaviors.appLinksNoTranslate = {
+    attach: function (context, settings) {
+      let $app_link = $("a.call-to-action");
+
+      $app_link.once('app-links-no-translate').each(function() {
+        let apphref = this.href;
+        $(this)
+          .attr("data-nid-app", apphref.substring(apphref.lastIndexOf("https://")))
+          .click(function(e) {
+            if ($(this).data("nid-app").length) {
+              e.originalEvent.currentTarget.href = decodeURIComponent($(this).data("nid-app"));
+            }
+          });
+      });
+
+    }
+  };
+
+}(jQuery, Drupal));

--- a/nidirect_common/js/translation-help.js
+++ b/nidirect_common/js/translation-help.js
@@ -1,0 +1,32 @@
+/**
+ * @file
+ * Defines Javascript behaviors for translation help.
+ *
+ * Modify links to Google translate to add on the referring page path.
+ * This ensures users get a translation of the page on which they hit the
+ * translation help button.
+ */
+(function ($) {
+
+  "use strict";
+
+  Drupal.behaviors.translationHelp = {
+    attach: function (context, settings) {
+
+      const translateReferrer = document.referrer;
+
+      // If the referrer is nidirect.
+      if (translateReferrer.length && translateReferrer.indexOf(document.location.origin) !== -1) {
+        // Replace the 'u' parameter in Google Translate links with the referrer.
+        // TODO: use URL and URLSearchParams objects for cleaner replacement (when IE11 support is discontinued).
+        $('a[href^="https://translate.google.com"]', context).once('translation-help-links').each(function () {
+          let thisHref = $(this).attr('href');
+          // Replace existing 'u' param with one containing the referrer.
+          thisHref = thisHref.replace(/&u=[^&#]*/, '&u=' + encodeURIComponent(translateReferrer));
+          $(this).attr('href', thisHref);
+        });
+      }
+    }
+  };
+
+}(jQuery, Drupal));

--- a/nidirect_common/nidirect_common.libraries.yml
+++ b/nidirect_common/nidirect_common.libraries.yml
@@ -17,3 +17,8 @@ related_info:
     - core/jquery
     - core/jquery.ui
     - core/drupal
+translation_help:
+  js:
+    js/translation-help.js: {}
+  dependencies:
+    - core/jquery

--- a/nidirect_common/nidirect_common.libraries.yml
+++ b/nidirect_common/nidirect_common.libraries.yml
@@ -22,3 +22,8 @@ translation_help:
     js/translation-help.js: {}
   dependencies:
     - core/jquery
+application_links:
+  js:
+    js/application-links-notranslate.js: {}
+  dependencies:
+    - core/jquery

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -516,3 +516,20 @@ function nidirect_common_page_attachments(array &$page) {
 
   $page['#attached']['library'][] = 'nidirect_common/translation_help';
 }
+
+/**
+ * Implements hook_preprocess_node().
+ */
+function nidirect_common_preprocess_node(array &$variables) {
+
+  $node = $variables['node'];
+
+  if (isset($node) && method_exists($node, 'bundle')) {
+    // Fix for application pages to prevent Google Translate altering the green button link URL.
+    // (We don't want applications opening in Google Translate).
+    if ($node->bundle() === 'application') {
+      $variables['#attached']['library'][] = 'nidirect_common/application_links';
+    }
+  }
+
+}

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -513,12 +513,13 @@ function nidirect_common_views_pre_view(ViewExecutable $view) {
 function nidirect_common_page_attachments(array &$page) {
 
   // Add translation help library to the translation help page.
+  $path_current = \Drupal::service('path.current')->getPath();
+  $translation_help_path = \Drupal::service('path_alias.manager')->getPathByAlias('/articles/translation-help');
 
-  if (\Drupal::service('path.current')->getPath() !== '/node/13488') {
-    return;
+  if ($path_current === $translation_help_path) {
+    $page['#attached']['library'][] = 'nidirect_common/translation_help';
   }
 
-  $page['#attached']['library'][] = 'nidirect_common/translation_help';
 }
 
 /**

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -502,3 +502,17 @@ function nidirect_common_views_pre_view(ViewExecutable $view) {
     $response->send();
   }
 }
+
+/**
+ * Implements hook_page_attachments().
+ */
+function nidirect_common_page_attachments(array &$page) {
+
+  // Add translation help library to the translation help page.
+
+  if (\Drupal::service('path.current')->getPath() !== '/node/13488') {
+    return;
+  }
+
+  $page['#attached']['library'][] = 'nidirect_common/translation_help';
+}

--- a/nidirect_common/src/LinkitSuggestionManager.php
+++ b/nidirect_common/src/LinkitSuggestionManager.php
@@ -37,7 +37,7 @@ class LinkitSuggestionManager extends SuggestionManager {
   /**
    * {@inheritdoc}
    */
-  public function getSuggestions(ProfileInterface $linkitProfile, string $search_string) {
+  public function getSuggestions(ProfileInterface $linkitProfile, $search_string) {
 
     $suggestions = new SuggestionCollection();
 

--- a/nidirect_common/src/Plugin/Block/TranslationHelpBlock.php
+++ b/nidirect_common/src/Plugin/Block/TranslationHelpBlock.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Drupal\nidirect_common\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Block\BlockPluginInterface;
+use Drupal\Core\Form\FormBuilderInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Url;
+
+/**
+ * Provides the Translation Help Block.
+ *
+ * @Block(
+ *   id = "translation_help_block",
+ *   admin_label = @Translation("Translation help link"),
+ *   category = @Translation("Translation help link"),
+ * )
+ */
+class TranslationHelpBlock extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+
+    $config = $this->getConfiguration();
+    $translation_help_link_title = isset($config['title']) ? $config['title'] : '';
+    $transalation_help_link_url = isset($config['url']) ? $config['url'] : '';
+
+    return [
+      '#title' => $this->t($translation_help_link_title),
+      '#type' => 'link',
+      '#url' => Url::fromUri($transalation_help_link_url),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockForm($form, FormStateInterface $form_state) {
+    $form = parent::blockForm($form, $form_state);
+
+    // Retrieve existing configuration for this block.
+    $config = $this->getConfiguration();
+
+    $form['url'] = [
+      '#type' => 'url',
+      '#title' => 'Link',
+      '#description' => 'The URL for translation help link.',
+      '#required' => TRUE,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockSubmit($form, FormStateInterface $form_state) {
+    // Save our custom settings when the form is submitted.
+    $this->setConfigurationValue('url', $form_state->getValue('url'));
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function blockValidate($form, FormStateInterface $form_state) {
+   
+  }
+
+}
+

--- a/nidirect_common/src/Plugin/Block/TranslationHelpBlock.php
+++ b/nidirect_common/src/Plugin/Block/TranslationHelpBlock.php
@@ -102,7 +102,7 @@ class TranslationHelpBlock extends BlockBase implements ContainerFactoryPluginIn
       ];
     }
 
-   return $block_content;
+    return $block_content;
 
   }
 

--- a/nidirect_common/src/Plugin/Block/TranslationHelpBlock.php
+++ b/nidirect_common/src/Plugin/Block/TranslationHelpBlock.php
@@ -3,6 +3,7 @@
 namespace Drupal\nidirect_common\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Cache\Cache;
 use Drupal\Core\Url;
 
 /**
@@ -21,15 +22,29 @@ class TranslationHelpBlock extends BlockBase {
    */
   public function build() {
 
+    $uri = \Drupal::request()->getRequestUri();
+    $query = [
+      'uri' => $uri,
+    ];
+
     return [
-      '#type' => 'link',
-      '#title' => $this->t('How to translate this page'),
-      '#url' => Url::fromRoute('entity.node.canonical', ['node' => 13488]),
       '#attributes' => [
-        'class' => ['translation-help'],
+        'class' => ['section-translation-help'],
+      ],
+      'translation-help-link' => [
+        '#type' => 'link',
+        '#title' => $this->t('How to translate this page'),
+        '#url' => Url::fromRoute('entity.node.canonical', ['node' => 13488, $query]),
+        '#attributes' => [
+          'class' => ['section-translation-help__link'],
+        ]
       ],
     ];
   }
 
-}
+  public function getCacheMaxAge() {
+    // The output for this block differs on every page - so don't cache it.
+    return 0;
+  }
 
+}

--- a/nidirect_common/src/Plugin/Block/TranslationHelpBlock.php
+++ b/nidirect_common/src/Plugin/Block/TranslationHelpBlock.php
@@ -3,12 +3,6 @@
 namespace Drupal\nidirect_common\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Block\BlockPluginInterface;
-use Drupal\Core\Form\FormBuilderInterface;
-use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Access\AccessResult;
-use Drupal\Core\Cache\Cache;
 use Drupal\Core\Url;
 
 /**
@@ -27,49 +21,14 @@ class TranslationHelpBlock extends BlockBase {
    */
   public function build() {
 
-    $config = $this->getConfiguration();
-    $translation_help_link_title = isset($config['title']) ? $config['title'] : '';
-    $transalation_help_link_url = isset($config['url']) ? $config['url'] : '';
-
     return [
-      '#title' => $this->t($translation_help_link_title),
       '#type' => 'link',
-      '#url' => Url::fromUri($transalation_help_link_url),
+      '#title' => $this->t('How to translate this page'),
+      '#url' => Url::fromRoute('entity.node.canonical', ['node' => 13488]),
+      '#attributes' => [
+        'class' => ['translation-help'],
+      ],
     ];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function blockForm($form, FormStateInterface $form_state) {
-    $form = parent::blockForm($form, $form_state);
-
-    // Retrieve existing configuration for this block.
-    $config = $this->getConfiguration();
-
-    $form['url'] = [
-      '#type' => 'url',
-      '#title' => 'Link',
-      '#description' => 'The URL for translation help link.',
-      '#required' => TRUE,
-    ];
-
-    return $form;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function blockSubmit($form, FormStateInterface $form_state) {
-    // Save our custom settings when the form is submitted.
-    $this->setConfigurationValue('url', $form_state->getValue('url'));
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function blockValidate($form, FormStateInterface $form_state) {
-   
   }
 
 }

--- a/nidirect_common/src/Plugin/Block/TranslationHelpBlock.php
+++ b/nidirect_common/src/Plugin/Block/TranslationHelpBlock.php
@@ -34,7 +34,10 @@ class TranslationHelpBlock extends BlockBase {
       'translation-help-link' => [
         '#type' => 'link',
         '#title' => $this->t('How to translate this page'),
-        '#url' => Url::fromRoute('entity.node.canonical', ['node' => 13488, $query]),
+        '#url' => Url::fromRoute(
+          'entity.node.canonical',
+          ['node' => 13488, $query]
+        ),
         '#attributes' => [
           'class' => ['section-translation-help__link'],
         ]
@@ -42,6 +45,9 @@ class TranslationHelpBlock extends BlockBase {
     ];
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public function getCacheMaxAge() {
     // The output for this block differs on every page - so don't cache it.
     return 0;


### PR DESCRIPTION
A simple block to output the translation help link plus javascript to process the Google Translate links on /articles/translation-help and add in the referring URL to be translated.

Related PRs: https://github.com/dof-dss/nidirect-drupal/pull/643, https://github.com/dof-dss/nicsdru_nidirect_theme/pull/258