### PR TITLE
Enable entities that don't have a field_banner_image to display one.

### DIFF
--- a/nidirect_common/inc/preprocess.inc
+++ b/nidirect_common/inc/preprocess.inc
@@ -48,9 +48,8 @@ function nidirect_common_preprocess_page(&$variables) {
     $entity = $variables['term'];
   }
 
-  // If the entity has a banner image field, fetch and display the node or
-  // theme banner image and footer text.
-  if (!empty($entity) && $entity->hasField('field_banner_image')) {
+  // Fetch and display the node or theme banner image and footer text.
+  if (!empty($entity)) {
     $banner_image = _retrieve_hierarchical_field($entity, 'field_banner_image');
 
     if (!empty($banner_image)) {


### PR DESCRIPTION
At present, only certain node types which themselves have a field_banner_image field can show a thin banner from the parent theme (when the node's field_banner_image field is empty).

This small change allows any node to show a thin banner from the parent theme regardless of whether it itself has a field_banner_image field or not.  This allows webforms, publications and other node types to show the thin banner set on the theme for the node.