### PR TITLE
D8 nid 1363

### DIFF
--- a/nidirect_common/inc/preprocess.inc
+++ b/nidirect_common/inc/preprocess.inc
@@ -103,7 +103,9 @@ function nidirect_common_preprocess_form_element(&$variables) {
   $route = \Drupal::routeMatch()->getRouteName();
 
   // Force the admin Content Theme/Subtheme select element onto a new line.
-  if ($route === 'system.admin_content' && $variables['element']['#id'] === 'edit-term-node-tid-depth') {
+  if ($route === 'system.admin_content'
+    && isset($variables['element']['#id'])
+    && $variables['element']['#id'] === 'edit-term-node-tid-depth') {
     $variables['attributes']['style'] = "float: none; clear: both";
   }
 }

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -543,33 +543,3 @@ function nidirect_common_preprocess_node(array &$variables) {
   }
 
 }
-
-/**
- * Implements hook_entity_delete().
- *
- * Log redirect deletion to watchdog.
- */
-function nidirect_common_entity_delete(EntityInterface $entity) {
-  // Are we deleting a redirect entity ?
-  if ($entity->bundle() == 'redirect') {
-    // Extract the redirect destination details from the
-    // string in the format 'internal:/node/nnnn'.
-    $destination = $entity->getRedirect()['uri'];
-    $destination = str_replace("internal:", "", $destination);
-    $nid = str_replace("/node/", "", $destination);
-    // Get the node alias for extra info.
-    $alias = \Drupal::service('path.alias_manager')->getAliasByPath($destination);
-    // Get the redirect source.
-    $source = $entity->get('redirect_source')->get(0)->getUrl()->toString();
-    // Track the current user.
-    $username = \Drupal::currentUser()->getAccountName();
-    $message = t("Redirect from @source to @alias (nid @nid) deleted by @username",
-      [
-        '@source' => $source,
-        '@alias' => $alias,
-        '@nid' => $nid,
-        '@username' => $username
-      ]);
-    \Drupal::logger('redirect_deletion')->notice($message);
-  }
-}

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -570,6 +570,6 @@ function nidirect_common_entity_delete(EntityInterface $entity) {
         '@nid' => $nid,
         '@username' => $username
       ]);
-    \Drupal::logger('redirect')->notice($message);
+    \Drupal::logger('redirect_deletion')->notice($message);
   }
 }

--- a/nidirect_dblog/nidirect_dblog.info.yml
+++ b/nidirect_dblog/nidirect_dblog.info.yml
@@ -1,0 +1,7 @@
+name: 'NIDirect DBLog'
+type: module
+description: 'NIDirect dblog overrides'
+core_version_requirement: ^8.8 || ^9
+package: 'NIDirect'
+dependencies:
+  - dblog

--- a/nidirect_dblog/nidirect_dblog.module
+++ b/nidirect_dblog/nidirect_dblog.module
@@ -7,6 +7,8 @@
  * Contains dblog overrides.
  */
 
+use Drupal\Core\Entity\EntityInterface;
+
 /**
  * Implements hook_entity_delete().
  *
@@ -58,10 +60,14 @@ function nidirect_dblog_cron() {
       ->range($row_limit - 1, 1)
       ->execute()->fetchField();
 
-    // Delete all table entries older than the nth row, if nth row was found.
+    // Delete all table entries older than the nth row, if nth row was found,
+    // but never delete 'content' or 'redirect_deletion' entries as we need
+    // to keep a track of these.
     if ($min_row) {
       $connection->delete('watchdog')
         ->condition('wid', $min_row, '<')
+        ->condition('type', 'redirect_deletion', '<>' )
+        ->condition('type', 'content', '<>' )
         ->execute();
     }
   }

--- a/nidirect_dblog/nidirect_dblog.module
+++ b/nidirect_dblog/nidirect_dblog.module
@@ -37,3 +37,33 @@ function nidirect_dblog_entity_delete(EntityInterface $entity) {
   }
 }
 
+/**
+ * Implements hook_cron().
+ *
+ * Controls the size of the log table, paring it to 'dblog_row_limit' messages,
+ * (this overrides the dblog_cron processing).
+ */
+function nidirect_dblog_cron() {
+  // Cleanup the watchdog table.
+  $row_limit = \Drupal::config('dblog.settings')->get('row_limit');
+
+  // For row limit n, get the wid of the nth row in descending wid order.
+  // Counting the most recent n rows avoids issues with wid number sequences,
+  // e.g. auto_increment value > 1 or rows deleted directly from the table.
+  if ($row_limit > 0) {
+    $connection = \Drupal::database();
+    $min_row = $connection->select('watchdog', 'w')
+      ->fields('w', ['wid'])
+      ->orderBy('wid', 'DESC')
+      ->range($row_limit - 1, 1)
+      ->execute()->fetchField();
+
+    // Delete all table entries older than the nth row, if nth row was found.
+    if ($min_row) {
+      $connection->delete('watchdog')
+        ->condition('wid', $min_row, '<')
+        ->execute();
+    }
+  }
+}
+

--- a/nidirect_dblog/nidirect_dblog.module
+++ b/nidirect_dblog/nidirect_dblog.module
@@ -66,10 +66,9 @@ function nidirect_dblog_cron() {
     if ($min_row) {
       $connection->delete('watchdog')
         ->condition('wid', $min_row, '<')
-        ->condition('type', 'redirect_deletion', '<>' )
-        ->condition('type', 'content', '<>' )
+        ->condition('type', 'redirect_deletion', '<>')
+        ->condition('type', 'content', '<>')
         ->execute();
     }
   }
 }
-

--- a/nidirect_dblog/nidirect_dblog.module
+++ b/nidirect_dblog/nidirect_dblog.module
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @file
+ * Contains nidirect_dblog.module.
+ *
+ * Contains dblog overrides.
+ */
+
+/**
+ * Implements hook_entity_delete().
+ *
+ * Log redirect deletion to watchdog.
+ */
+function nidirect_dblog_entity_delete(EntityInterface $entity) {
+  // Are we deleting a redirect entity ?
+  if ($entity->bundle() == 'redirect') {
+    // Extract the redirect destination details from the
+    // string in the format 'internal:/node/nnnn'.
+    $destination = $entity->getRedirect()['uri'];
+    $destination = str_replace("internal:", "", $destination);
+    $nid = str_replace("/node/", "", $destination);
+    // Get the node alias for extra info.
+    $alias = \Drupal::service('path.alias_manager')->getAliasByPath($destination);
+    // Get the redirect source.
+    $source = $entity->get('redirect_source')->get(0)->getUrl()->toString();
+    // Track the current user.
+    $username = \Drupal::currentUser()->getAccountName();
+    $message = t("Redirect from @source to @alias (nid @nid) deleted by @username",
+      [
+        '@source' => $source,
+        '@alias' => $alias,
+        '@nid' => $nid,
+        '@username' => $username
+      ]);
+    \Drupal::logger('redirect_deletion')->notice($message);
+  }
+}
+


### PR DESCRIPTION
Create new nidirect_dblog module and move hook_entity_delete processing over from nidirect_common.

Implement nidirect_dblog_cron to override dblog_cron - the new processing is more selective and does not delete certain log entries that we would like to keep (redirect deletion and content updates).

See associated PR https://github.com/dof-dss/nidirect-drupal/pull/780