### PR TITLE
A11y fixes

### DIFF
--- a/nidirect_contacts/src/Plugin/Field/FieldFormatter/GMapsLazyLoadFormatter.php
+++ b/nidirect_contacts/src/Plugin/Field/FieldFormatter/GMapsLazyLoadFormatter.php
@@ -236,6 +236,8 @@ class GMapsLazyLoadFormatter extends FormatterBase implements ContainerFactoryPl
         '#attributes' => [
           'class' => ['gmap', 'gmap-lazy-load'],
           'id' => Html::getUniqueId('gmap-lazy-load'),
+          'title' => t('Google Map'),
+          'role' => 'application',
           'data-lat' => $map_settings['lat'],
           'data-lng' => $map_settings['lng'],
           'data-maptype' => $map_settings['map_type'],

--- a/nidirect_contacts/src/Plugin/Field/FieldFormatter/GMapsLazyLoadFormatter.php
+++ b/nidirect_contacts/src/Plugin/Field/FieldFormatter/GMapsLazyLoadFormatter.php
@@ -236,8 +236,8 @@ class GMapsLazyLoadFormatter extends FormatterBase implements ContainerFactoryPl
         '#attributes' => [
           'class' => ['gmap', 'gmap-lazy-load'],
           'id' => Html::getUniqueId('gmap-lazy-load'),
-          'title' => t('Google Map'),
           'role' => 'application',
+          'aria-roledescription' => t('Google Map'),
           'data-lat' => $map_settings['lat'],
           'data-lng' => $map_settings['lng'],
           'data-maptype' => $map_settings['map_type'],

--- a/nidirect_webforms/templates/nidirect-webforms-quiz-answer-feedback.html.twig
+++ b/nidirect_webforms/templates/nidirect-webforms-quiz-answer-feedback.html.twig
@@ -8,9 +8,13 @@
   <span class="subtitle">{{ question }}</span>
 </h3>
 <details{{ attributes.addClass(quiz_feedback_classes) }} open="open">
-  <summary aria-label="Your answer">
+  <summary>
+    <span class="visually-hidden">Your answer: </span>
     {{ user_answer }}
-    <span class="{{ passed ? 'success' : 'error' }}" aria-label="is">{{ passed ? 'correct' : 'wrong' }}</span>
+    <span class="{{ passed ? 'success' : 'error' }}">
+      <span class="visually-hidden"> is </span>
+      {{ passed ? 'correct' : 'wrong' }}
+    </span>
   </summary>
   {{ feedback }}
 </details>


### PR DESCRIPTION
Webform quiz feedback twig - remove aria-labels as they replace rather than prefix the content of the element. Use visually hidden spans instead to output text for screen readers.

Google map field formatter - set attributes on map container to help screen readers handle it in an appropriate way.   https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Application_Role. 