### PR TITLE
Purge the cache item for the taxo term list of the newly selected term

### DIFF
--- a/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
+++ b/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
@@ -51,7 +51,9 @@ class InvalidateTaxonomyListCacheTags {
     foreach ($field_list as $thisfield) {
       if ($entity->hasField($thisfield)) {
         $tid = $entity->get($thisfield)->target_id;
-        // If landing page, get parent.
+        $taxonomy_tags[] = 'taxonomy_term_list:' . $tid;
+
+        // If landing page, get parent as well.
         if (!empty($tid)) {
           $tid = $this->checkLandingPageParent($entity, $tid);
           $taxonomy_tags[] = 'taxonomy_term_list:' . $tid;
@@ -67,6 +69,7 @@ class InvalidateTaxonomyListCacheTags {
         }
       }
     }
+
     if (count($taxonomy_tags) > 0) {
       $this->cacheTagsInvalidator->invalidateTags($taxonomy_tags);
     }


### PR DESCRIPTION
As well as any parent terms for landing page nodes.

Without this, the landing page only clears render items tagged with the past subtheme and the parent term of the new one. This one includes the subtheme term plus parent, and expires the past subtheme term too so there's no stale remnant of the content in the listing.