### PR TITLE
D8 nid 1388

### DIFF
--- a/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
+++ b/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
@@ -51,7 +51,9 @@ class InvalidateTaxonomyListCacheTags {
     foreach ($field_list as $thisfield) {
       if ($entity->hasField($thisfield)) {
         $tid = $entity->get($thisfield)->target_id;
-        // If landing page, get parent.
+        $taxonomy_tags[] = 'taxonomy_term_list:' . $tid;
+
+        // If landing page, get parent as well.
         if (!empty($tid)) {
           $tid = $this->checkLandingPageParent($entity, $tid);
           $taxonomy_tags[] = 'taxonomy_term_list:' . $tid;
@@ -67,6 +69,7 @@ class InvalidateTaxonomyListCacheTags {
         }
       }
     }
+
     if (count($taxonomy_tags) > 0) {
       $this->cacheTagsInvalidator->invalidateTags($taxonomy_tags);
     }

--- a/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
+++ b/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
@@ -5,6 +5,7 @@ namespace Drupal\nidirect_common;
 use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\node\NodeInterface;
 
 /**
  * Utility class to invalidates theme taxonomy cache tags.
@@ -60,11 +61,15 @@ class InvalidateTaxonomyListCacheTags {
         }
         // If this is an update, invalidate cache tag for
         // original taxonomy term as well.
-        if (isset($entity->original)) {
+        if ($entity->original instanceof NodeInterface) {
           $tid = $entity->original->get($thisfield)->target_id;
           if (!empty($tid)) {
-            $tid = $this->checkLandingPageParent($entity, $tid);
             $taxonomy_tags[] = 'taxonomy_term_list:' . $tid;
+            $parent_tid = $this->checkLandingPageParent($entity, $tid);
+
+            if (!empty($parent_tid)) {
+              $taxonomy_tags[] = 'taxonomy_term_list:' . $parent_tid;
+            }
           }
         }
       }

--- a/nidirect_landing_pages/nidirect_landing_pages.module
+++ b/nidirect_landing_pages/nidirect_landing_pages.module
@@ -403,6 +403,9 @@ function nidirect_landing_pages_get_redirect_url(string $source_path) {
  *   The landing page node entity.
  */
 function nidirect_landing_pages_create_landing_page_redirect(EntityInterface $entity) {
+  // Purge any existing redirect for this entity before we create a new one.
+  nidirect_landing_pages_delete_landing_page_redirect($entity);
+
   $subtheme_tid = $entity->get('field_subtheme')->getString();
   $taxonomy_term_path = 'taxonomy/term/' . $subtheme_tid;
   $redirect_url = nidirect_landing_pages_get_redirect_url($taxonomy_term_path);


### PR DESCRIPTION
Without this, changing a LP's theme value will leave a dangling redirect which can be pruned away manually easily enough but is causing confusion even for seasoned NIDirect testers, let alone casual editors.

Adding a taxo list to expire too so when the change is made, the taxo list for the theme previously used is also expired as well as a parent term list which landing pages also seem to need.