### PR TITLE
D8NID-1447 theme to landing page redirect fix

### DIFF
--- a/nidirect_landing_pages/nidirect_landing_pages.module
+++ b/nidirect_landing_pages/nidirect_landing_pages.module
@@ -43,7 +43,7 @@ function nidirect_landing_pages_entity_update(EntityInterface $entity) {
     else {
       // Delete any URL redirects associated with this node when in an
       // unpublished(draft, archive) state.
-      nidirect_landing_pages_delete_landing_page_redirect($entity);
+      nidirect_landing_pages_delete_landing_page_redirect($entity->original);
     }
   }
 }
@@ -403,8 +403,8 @@ function nidirect_landing_pages_get_redirect_url(string $source_path) {
  *   The landing page node entity.
  */
 function nidirect_landing_pages_create_landing_page_redirect(EntityInterface $entity) {
-  // Purge any existing redirect for this entity before we create a new one.
-  nidirect_landing_pages_delete_landing_page_redirect($entity);
+  // Delete any existing redirect for this entity before we create a new one.
+  nidirect_landing_pages_delete_landing_page_redirect($entity->original);
 
   $subtheme_tid = $entity->get('field_subtheme')->getString();
   $taxonomy_term_path = 'taxonomy/term/' . $subtheme_tid;
@@ -447,18 +447,28 @@ function nidirect_landing_pages_create_landing_page_redirect(EntityInterface $en
 }
 
 /**
- * Deletes a landing page redirect.
+ * Deletes a theme to landing page redirect.
  *
  * @param \Drupal\Core\Entity\EntityInterface $entity
  *   The landing page node.
  */
 function nidirect_landing_pages_delete_landing_page_redirect(EntityInterface $entity) {
   $redirect_repository = \Drupal::service('redirect.repository');
+
+  // The redirect to delete must have a source path that matches
+  // the path of the theme taxonomy term for the landing page and
+  // a destination path that matches the landing page node path.
+  $subtheme_tid = $entity->get('field_subtheme')->getString();
+  $source_path = '/taxonomy/term/' . $subtheme_tid;
   $destination_path[] = 'internal:/node/' . $entity->id();
 
+  // Get all redirects whose destination is the landing page.
   $redirects = $redirect_repository->findByDestinationUri($destination_path);
   foreach ($redirects as $redirect) {
-    $redirect->delete();
+    // Delete the redirect if its source is landing page theme path.
+    if ($redirect->getSourceUrl() == $source_path) {
+      $redirect->delete();
+    }
   }
 }
 

--- a/nidirect_landing_pages/nidirect_landing_pages.module
+++ b/nidirect_landing_pages/nidirect_landing_pages.module
@@ -21,12 +21,10 @@ use Drupal\taxonomy\Entity\Term;
  */
 function nidirect_landing_pages_entity_insert(EntityInterface $entity) {
 
-  if (isset($entity->moderation_state) && nidirect_landing_pages_is_node_with_subtheme_value($entity)) {
-    if ($entity->moderation_state->value == 'published') {
-      // Create a redirect from the taxonomy term when a landing page is created
-      // (as long as a subtheme has been selected and the node is published).
-      nidirect_landing_pages_create_landing_page_redirect($entity);
-    }
+  // Create a redirect from the taxonomy term when a landing page is created
+  // if a subtheme has been selected and the node is published.
+  if (nidirect_landing_pages_is_node_with_subtheme_value($entity) && $entity->isPublished()) {
+    nidirect_landing_pages_create_theme_to_landing_page_redirect($entity);
   }
 }
 
@@ -34,16 +32,18 @@ function nidirect_landing_pages_entity_insert(EntityInterface $entity) {
  * Implements hook_entity_update().
  */
 function nidirect_landing_pages_entity_update(EntityInterface $entity) {
-  if (isset($entity->moderation_state) && nidirect_landing_pages_is_node_with_subtheme_value($entity)) {
-    if ($entity->moderation_state->value == 'published') {
-      // Create a redirect from the taxonomy term when a landing page is created
-      // (as long as a subtheme has been selected and the node is published).
-      nidirect_landing_pages_create_landing_page_redirect($entity);
+
+  // Update theme redirect when default revision is published or
+  // remove the theme redirect if (not published and) it is a default revision.
+  if (nidirect_landing_pages_is_node_with_subtheme_value($entity)) {
+    if ($entity->isPublished()) {
+      // Update is publishing the page - remove and re-create theme redirect.
+      nidirect_landing_pages_delete_theme_to_landing_page_redirect($entity->original);
+      nidirect_landing_pages_create_theme_to_landing_page_redirect($entity);
     }
-    else {
-      // Delete any URL redirects associated with this node when in an
-      // unpublished(draft, archive) state.
-      nidirect_landing_pages_delete_landing_page_redirect($entity->original);
+    else if ($entity->isDefaultRevision()) {
+      // Un-published default revision - remove theme redirect.
+      nidirect_landing_pages_delete_theme_to_landing_page_redirect($entity->original);
     }
   }
 }
@@ -402,14 +402,15 @@ function nidirect_landing_pages_get_redirect_url(string $source_path) {
  * @param \Drupal\Core\Entity\EntityInterface $entity
  *   The landing page node entity.
  */
-function nidirect_landing_pages_create_landing_page_redirect(EntityInterface $entity) {
-  // Delete any existing redirect for this entity before we create a new one.
-  nidirect_landing_pages_delete_landing_page_redirect($entity->original);
+function nidirect_landing_pages_create_theme_to_landing_page_redirect(EntityInterface $entity) {
 
+  // Determine the theme path that will be the redirect source.
   $subtheme_tid = $entity->get('field_subtheme')->getString();
   $taxonomy_term_path = 'taxonomy/term/' . $subtheme_tid;
-  $redirect_url = nidirect_landing_pages_get_redirect_url($taxonomy_term_path);
 
+  // Create a theme redirect if there is no existing redirect
+  // where the theme path is the redirect source.
+  $redirect_url = nidirect_landing_pages_get_redirect_url($taxonomy_term_path);
   if (empty($redirect_url)) {
     Redirect::create([
       'redirect_source' => $taxonomy_term_path,
@@ -419,7 +420,7 @@ function nidirect_landing_pages_create_landing_page_redirect(EntityInterface $en
     ])->save();
   }
   else {
-    // Just check that the redirect is not for the current node.
+    // Just check that the existing redirect is not for the current node.
     $current_node = \Drupal::routeMatch()->getParameter('node');
     if (!empty($current_node)) {
       $this_alias = \Drupal::service('path_alias.manager')->getAliasByPath('/node/' . $current_node->id());
@@ -452,7 +453,7 @@ function nidirect_landing_pages_create_landing_page_redirect(EntityInterface $en
  * @param \Drupal\Core\Entity\EntityInterface $entity
  *   The landing page node.
  */
-function nidirect_landing_pages_delete_landing_page_redirect(EntityInterface $entity) {
+function nidirect_landing_pages_delete_theme_to_landing_page_redirect(EntityInterface $entity) {
   $redirect_repository = \Drupal::service('redirect.repository');
 
   // The redirect to delete must have a source path that matches

--- a/nidirect_landing_pages/nidirect_landing_pages.module
+++ b/nidirect_landing_pages/nidirect_landing_pages.module
@@ -41,7 +41,7 @@ function nidirect_landing_pages_entity_update(EntityInterface $entity) {
       nidirect_landing_pages_delete_theme_to_landing_page_redirect($entity->original);
       nidirect_landing_pages_create_theme_to_landing_page_redirect($entity);
     }
-    else if ($entity->isDefaultRevision()) {
+    elseif ($entity->isDefaultRevision()) {
       // Un-published default revision - remove theme redirect.
       nidirect_landing_pages_delete_theme_to_landing_page_redirect($entity->original);
     }


### PR DESCRIPTION
The existing logic for creating theme to landing page redirects was deleting all redirects (then creating a new redirect from the theme) every time the page was updated.  If the page update was creation of a pending draft - all redirects including the theme redirect were deleted.  This fix targets a specific redirect and creates or deletes it only when the page update publishes or unpublishes the page.  If a page is published, an an editor creates a pending draft, the theme redirect remains in place.