### PR TITLE
CircleCI config fixes (plus a11y fix for webform select other components)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
           name: Fetch phpcs and dependencies
           command: |
             composer require drupal/coder --prefer-stable --no-interaction --optimize-autoloader
+            composer require slevomat/coding-standard --dev --no-interaction --optimize-autoloader
             # Move vendor directory up a level as we don't want to code-check all of that.
             mv vendor ../
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,6 @@ jobs:
           command: |
             composer require drupal/coder --prefer-stable --no-interaction --optimize-autoloader
             composer require slevomat/coding-standard --prefer-stable --no-interaction --optimize-autoloader
-            composer require phpspec/prophecy-phpunit:^2 --dev --no-interaction --optimize-autoloader
             # Move vendor directory up a level as we don't want to code-check all of that.
             mv vendor ../
       - run:
@@ -46,10 +45,10 @@ jobs:
             cd /home/circleci
             composer create-project drupal-composer/drupal-project:9.x-dev /home/circleci/project --no-interaction
       - run:
-          name: Download dependent contrib modules.
+          name: Download dependent contrib modules and other dependencies.
           command: |
             cd /home/circleci/project
-            composer require drupal/telephone_plus drupal/webform drupal/linkit:^6.0 mglaman/drupal-check --no-interaction
+            composer require drupal/telephone_plus drupal/webform drupal/linkit:^6.0 mglaman/drupal-check phpspec/prophecy-phpunit:^2 --no-interaction
       - run:
           name: Move custom code into position
           command: mv /home/circleci/nidirect-site-modules /home/circleci/project/web/modules/custom

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
           command: |
             composer require drupal/coder --prefer-stable --no-interaction --optimize-autoloader
             composer require slevomat/coding-standard --prefer-stable --no-interaction --optimize-autoloader
+            composer require phpspec/prophecy-phpunit:^2 --dev --no-interaction --optimize-autoloader
             # Move vendor directory up a level as we don't want to code-check all of that.
             mv vendor ../
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run:
           name: Fetch phpcs and dependencies
           command: |
-            composer require drupal/coder --dev --no-interaction --optimize-autoloader
+            composer require drupal/coder --prefer-stable --no-interaction
             # Move vendor directory up a level as we don't want to code-check all of that.
             mv vendor ../
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - run:
           name: Fetch phpcs convenience script
           command: |
-            curl https://raw.githubusercontent.com/dof-dss/nidirect-drupal/main/phpcs.sh -o /home/circleci/project/phpcs.sh
+            curl https://raw.githubusercontent.com/dof-dss/nidirect-drupal/development/phpcs.sh -o /home/circleci/project/phpcs.sh
             chmod +x /home/circleci/project/phpcs.sh
       - run:
           name: PHPCS analysis

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,12 +43,12 @@ jobs:
           name: Fetch latest Drupal version
           command: |
             cd /home/circleci
-            composer create-project drupal-composer/drupal-project:9.x-dev /home/circleci/project --no-interaction
+            composer create-project drupal-composer/drupal-project:8.x-dev /home/circleci/project --no-interaction
       - run:
           name: Download dependent contrib modules and other dependencies.
           command: |
             cd /home/circleci/project
-            composer require drupal/telephone_plus drupal/webform drupal/linkit:^6.0 mglaman/drupal-check phpspec/prophecy-phpunit:^2 --no-interaction
+            composer require drupal/telephone_plus drupal/webform drupal/linkit:^6.0 mglaman/drupal-check --no-interaction
       - run:
           name: Move custom code into position
           command: mv /home/circleci/nidirect-site-modules /home/circleci/project/web/modules/custom

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,4 +63,4 @@ workflows:
   static-analysis:
     jobs:
       - coding_standards
-      - deprecated_code
+ #     - deprecated_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           name: Fetch latest Drupal version
           command: |
             cd /home/circleci
-            composer create-project drupal-composer/drupal-project:8.x-dev /home/circleci/project --no-interaction
+            composer create-project drupal-composer/drupal-project:9.x-dev /home/circleci/project --no-interaction
       - run:
           name: Download dependent contrib modules.
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,8 @@ jobs:
       - run:
           name: Fetch phpcs and dependencies
           command: |
-            composer require drupal/coder --no-interaction
+            composer require drupal/coder --prefer-stable --no-interaction --optimize-autoloader
+            composer require slevomat/coding-standard --prefer-stable --no-interaction --optimize-autoloader
             # Move vendor directory up a level as we don't want to code-check all of that.
             mv vendor ../
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - run:
           name: Fetch phpcs and dependencies
           command: |
-            composer require drupal/coder --prefer-stable --no-interaction
+            composer require drupal/coder --no-interaction
             # Move vendor directory up a level as we don't want to code-check all of that.
             mv vendor ../
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,7 @@ jobs:
       - run:
           name: Fetch phpcs and dependencies
           command: |
-            composer require drupal/coder --prefer-stable --no-interaction --optimize-autoloader
-            composer require slevomat/coding-standard --dev --no-interaction --optimize-autoloader
+            composer require drupal/coder --dev --no-interaction --optimize-autoloader
             # Move vendor directory up a level as we don't want to code-check all of that.
             mv vendor ../
       - run:

--- a/nidirect_webforms/nidirect_webforms.module
+++ b/nidirect_webforms/nidirect_webforms.module
@@ -169,6 +169,9 @@ function nidirect_webforms_honeypot_form_protections_alter(&$options, $form) {
   }
 }
 
+/**
+ * Implements hook_preprocess_form_element().
+ */
 function nidirect_webforms_preprocess_form_element(&$variables) {
 
   if (!WebformElementHelper::isWebformElement($variables['element'])) {

--- a/nidirect_webforms/nidirect_webforms.module
+++ b/nidirect_webforms/nidirect_webforms.module
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\webform\Utility\WebformElementHelper;
 use Drupal\webform\WebformSubmissionInterface;
 
 /**
@@ -165,5 +166,35 @@ function nidirect_webforms_honeypot_form_protections_alter(&$options, $form) {
         break;
       }
     }
+  }
+}
+
+function nidirect_webforms_preprocess_form_element(&$variables) {
+
+  if (!WebformElementHelper::isWebformElement($variables['element'])) {
+    return;
+  }
+
+  $element = $variables['element'];
+
+  // Fix a11y issue with webform_select_other element labels.
+  // @TODO: create issue on webform issue queue.
+
+  // The wrapping webform_select_other element has a visible label that IS NOT
+  // associated with the select element it contains. So we stop that one being
+  // displayed.
+  if ($element['#type'] === 'webform_select_other') {
+    $element['#title_display'] = 'none';
+    $variables['label_display'] = 'none';
+    $variables['label']['#title_display'] = 'none';
+  }
+
+  // The select element inside the webform_select_other element has a label
+  // that IS associated with the select (via a for attribute) is visually
+  // hidden.  We want that to be visible.
+  if (!empty($element['#webform_other'])) {
+    $element['#title_display'] = 'before';
+    $variables['label_display'] = 'before';
+    $variables['label']['#title_display'] = 'before';
   }
 }


### PR DESCRIPTION
This started out as an accessibility fix for webform "select other" components.  However, it morphed into a PR that fixes the  circleci config.
- Fix for "ERROR: Referenced sniff "SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator" does not exist" (see also https://github.com/dof-dss/nidirect-drupal/commit/cf43ffd4006be4b63df001d5e2db5cf2d9312170)
- Fetch the phpcs convenience script from main repo's dev branch instead of the main branch (then we can update it without it being deployed to production)
- Disable deprecated_code checks until extending of @internal class errors are resolved