### PR TITLE
Event subscriber to change cache header on ED waiting times page

### DIFF
--- a/nidirect_hospital_waiting_times/config/install/nidirect_hospital_waiting_times.settings.yml
+++ b/nidirect_hospital_waiting_times/config/install/nidirect_hospital_waiting_times.settings.yml
@@ -1,1 +1,2 @@
 data_source_url: "http://edxml.hscni.net/ed_pressures_data.xml"
+cache_duration: 10

--- a/nidirect_hospital_waiting_times/nidirect_hospital_waiting_times.services.yml
+++ b/nidirect_hospital_waiting_times/nidirect_hospital_waiting_times.services.yml
@@ -1,0 +1,6 @@
+services:
+  nidirect_hospital_waiting_times.http_headers_subscriber:
+    class: Drupal\nidirect_hospital_waiting_times\EventSubscriber\HttpHeadersSubscriber
+    arguments: ['@current_route_match', '@config.factory']
+    tags:
+      - { name: event_subscriber }

--- a/nidirect_hospital_waiting_times/src/EventSubscriber/HttpHeadersSubscriber.php
+++ b/nidirect_hospital_waiting_times/src/EventSubscriber/HttpHeadersSubscriber.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Drupal\nidirect_hospital_waiting_times\EventSubscriber;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class HttpHeadersSubscriber implements EventSubscriberInterface {
+
+  /**
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected RouteMatchInterface $currentRouteMatch;
+
+  /**
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected ConfigFactoryInterface $configFactory;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(RouteMatchInterface $current_route_match, ConfigFactoryInterface $config_factory) {
+    $this->currentRouteMatch = $current_route_match;
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * Looks for a known render string output by the
+   * [nidirect:hospital_emergency_waiting_times] token.
+   *
+   * If it's present, then we sync the surrogate-control header
+   * value to a lower value on the pages it appears on so that
+   * any hospital waiting times aren't cached for longer than
+   * the refresh interval on the data feed.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
+   *   The response event object from the event handler.
+   */
+  public function remoteSurrogateControlHeader(ResponseEvent $event) {
+    $response = $event->getResponse();
+    $content = $response->getContent();
+
+    // Is there emergency-department-average-waiting-times render markup in
+    // the response string?
+    if (preg_match('id="emergency-department-average-waiting-times"', $content)) {
+      $response->headers->remove('surrogate-control');
+      // Replace with config value for cache expiration.
+      $cache_duration = $this->configFactory->get('nidirect_hospital_waiting_times.settings')->get('cache_duration') ?? 10;
+
+      // Convert minutes from config into seconds for surrogate-control TTL.
+      $response->headers->set('surrogate-control', 'max-age=' . ($cache_duration * 60));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    // -100 weighting overrides other services such as those from
+    // http_cache_control and fastly modules.
+    $events[KernelEvents::RESPONSE][] = ['remoteSurrogateControlHeader', -100];
+    return $events;
+  }
+
+}

--- a/nidirect_hospital_waiting_times/templates/nidirect-hospital-waiting-times.html.twig
+++ b/nidirect_hospital_waiting_times/templates/nidirect-hospital-waiting-times.html.twig
@@ -1,21 +1,23 @@
-{% if hospitals|length > 0 %}
-<p>Last updated: {{ updated|time_diff }}.</p>
-<table>
-  <tbody>
-    <tr>
-      <th>Hospital/Unit</th>
-      <th>Opening hours</th>
-      <th>Average waiting time to be seen</th>
-    </tr>
-    {% for hospital in hospitals %}
-    <tr>
-      <td>{{ hospital.name }} - {{ hospital.type }}</td>
-      <td>{{ hospital.hours }}</td>
-      <td>{{ hospital.wait }}</td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table>
-{% else %}
-<p>Sorry, we are unable to display the hospital waiting times.</p>
-{% endif %}
+<div id="emergency-department-average-waiting-times">
+  {% if hospitals|length > 0 %}
+  <p>Last updated: {{ updated|date('g.i a, l j F Y') }}.</p>
+  <table>
+    <tbody>
+      <tr>
+        <th>Hospital/Unit</th>
+        <th>Opening hours</th>
+        <th>Average waiting time to be seen</th>
+      </tr>
+      {% for hospital in hospitals %}
+      <tr>
+        <td>{{ hospital.name }} - {{ hospital.type }}</td>
+        <td>{{ hospital.hours }}</td>
+        <td>{{ hospital.wait }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p>Sorry, we are unable to display the hospital waiting times.</p>
+  {% endif %}
+</div>


### PR DESCRIPTION
This borrows code Johan wrote to prevent Fastly caching the school closures page.  Like the school closures page, the ED waiting times page uses a token to output data from a feed.  The feed is updated every hour, but since the entire page is cached by Fastly for 24 hours (due to the surrogate-control max-age header set on all pages) then updated data never appears on the page when it should.  So using an event subscriber, we detect if the response contains rendered hospital waiting times and then change the surrogate-control max-age header to a much shorter period.