### PR TITLE
Do not output school closures on a specific path

### DIFF
--- a/nidirect_school_closures/nidirect_school_closures.module
+++ b/nidirect_school_closures/nidirect_school_closures.module
@@ -95,15 +95,3 @@ function nidirect_school_closures_render() {
   ];
 }
 
-/**
- * Implements hook_entity_view().
- */
-function nidirect_school_closures_entity_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
-  $current_path = \Drupal::request()->getPathInfo();
-  $closures_paths = \Drupal::getContainer()->getParameter('breadcrumb.schoolclosures.matches');
-
-  if (in_array($current_path, $closures_paths) && ($entity instanceof NodeInterface && $view_mode == 'full')) {
-    // Append the school closures info to the render array for this page.
-    $build['closures_info'] = nidirect_school_closures_render();
-  }
-}


### PR DESCRIPTION
(already output via token replacement)