### PR TITLE
Update to PHPstan level 2 compliance

### DIFF
--- a/nidirect_breadcrumbs/src/GovernmentContactBreadcrumb.php
+++ b/nidirect_breadcrumbs/src/GovernmentContactBreadcrumb.php
@@ -27,6 +27,20 @@ class GovernmentContactBreadcrumb implements BreadcrumbBuilderInterface {
   protected $entityTypeManager;
 
   /**
+   * Route match parameters.
+   *
+   * @var array
+   */
+  protected $routeMatches;
+
+  /**
+   * Request stack service object.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
    * Class constructor.
    *
    * @param array $route_matches

--- a/nidirect_breadcrumbs/src/NodeThemesBreadcrumb.php
+++ b/nidirect_breadcrumbs/src/NodeThemesBreadcrumb.php
@@ -197,9 +197,7 @@ class NodeThemesBreadcrumb implements BreadcrumbBuilderInterface {
       $cache_tags[] = 'node:' . $node->id();
     }
 
-    if (!empty($cache_tags)) {
-      $breadcrumb->addCacheTags($cache_tags);
-    }
+    $breadcrumb->addCacheTags($cache_tags);
 
     return $breadcrumb;
   }

--- a/nidirect_cold_weather_payments/src/Form/ColdWeatherPaymentCheckerForm.php
+++ b/nidirect_cold_weather_payments/src/Form/ColdWeatherPaymentCheckerForm.php
@@ -7,6 +7,7 @@ use Drupal\Core\Ajax\RemoveCommand;
 use Drupal\Core\Cache\CacheableAjaxResponse;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use GuzzleHttp\Exception\RequestException;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Http\ClientFactory;
 use Drupal\Core\Render\Renderer;
@@ -262,7 +263,7 @@ class ColdWeatherPaymentCheckerForm extends FormBase {
 
       $data['payments'] = $payments;
     }
-    catch (\Exception $e) {
+    catch (RequestException $e) {
       $data['has_error'] = TRUE;
       $data['response'] = $e->getResponse();
       \Drupal::logger('type')->error($e->getMessage());

--- a/nidirect_cold_weather_payments/src/Form/WeatherStationEntityForm.php
+++ b/nidirect_cold_weather_payments/src/Form/WeatherStationEntityForm.php
@@ -16,14 +16,14 @@ class WeatherStationEntityForm extends EntityForm {
   /**
    * EntityTypeManager.
    *
-   * @var Drupal\Core\Entity\EntityTypeManagerInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
 
   /**
    * Messenger service.
    *
-   * @var Drupal\Core\Messenger\MessengerInterface
+   * @var \Drupal\Core\Messenger\MessengerInterface
    */
   protected $messenger;
 
@@ -51,6 +51,7 @@ class WeatherStationEntityForm extends EntityForm {
   public function form(array $form, FormStateInterface $form_state) {
     $form = parent::form($form, $form_state);
 
+    /** @var \Drupal\Core\Entity\FieldableEntityInterface $weather_station */
     $weather_station = $this->entity;
     $form['label'] = [
       '#type' => 'textfield',
@@ -99,6 +100,7 @@ class WeatherStationEntityForm extends EntityForm {
     $stations = $this->entityTypeManager->getStorage('weather_station')->loadMultiple($ids);
 
     foreach ($stations as $station) {
+      /** @var \Drupal\Core\Entity\FieldableEntityInterface $station */
       $existing_postcodes = array_merge($existing_postcodes, explode(',', $station->get('postcodes')));
     }
 
@@ -115,6 +117,7 @@ class WeatherStationEntityForm extends EntityForm {
    * {@inheritdoc}
    */
   public function save(array $form, FormStateInterface $form_state) {
+    /** @var \Drupal\Core\Entity\FieldableEntityInterface $weather_station */
     $weather_station = $this->entity;
     $status = $weather_station->save();
 
@@ -131,6 +134,8 @@ class WeatherStationEntityForm extends EntityForm {
         ]));
     }
     $form_state->setRedirectUrl($weather_station->toUrl('collection'));
+
+    return $status;
   }
 
 }

--- a/nidirect_cold_weather_payments/src/Plugin/Field/FieldFormatter/ColdWeatherPeriodDefaultFormatter.php
+++ b/nidirect_cold_weather_payments/src/Plugin/Field/FieldFormatter/ColdWeatherPeriodDefaultFormatter.php
@@ -26,6 +26,10 @@ class ColdWeatherPeriodDefaultFormatter extends FormatterBase {
     $build = [];
 
     foreach ($items as $delta => $item) {
+      $date_start = $item->date_start ?? '';
+      $date_end = $item->date_end ?? '';
+      $stations = $item->stations ?? '';
+
       $build['name'] = [
         '#type' => 'container',
         'label' => [
@@ -34,8 +38,8 @@ class ColdWeatherPeriodDefaultFormatter extends FormatterBase {
             'class' => ['field__label'],
           ],
           '#markup' => t('%start - %end', [
-            '%start' => $item->date_start,
-            '%end' => $item->date_end,
+            '%start' => $date_start,
+            '%end' => $date_end,
           ]),
         ],
         'value' => [
@@ -44,7 +48,7 @@ class ColdWeatherPeriodDefaultFormatter extends FormatterBase {
             'class' => ['field__item'],
           ],
           'stations' => [
-            '#markup' => str_replace(',', ', ', $item->stations),
+            '#markup' => str_replace(',', ', ', $stations),
           ],
         ],
       ];

--- a/nidirect_cold_weather_payments/src/Plugin/Field/FieldWidget/ColdWeatherPeriodDefaultWidget.php
+++ b/nidirect_cold_weather_payments/src/Plugin/Field/FieldWidget/ColdWeatherPeriodDefaultWidget.php
@@ -58,6 +58,9 @@ class ColdWeatherPeriodDefaultWidget extends WidgetBase implements WidgetInterfa
    */
   public function formElement(FieldItemListInterface $items, $delta, array $element, array &$form, FormStateInterface $form_state) {
     $item =& $items[$delta];
+    $date_start = $item->date_start ?? '';
+    $date_end = $item->date_end ?? '';
+    $item_stations = $item->stations ?? [];
 
     $element += [
       '#type' => 'fieldset',
@@ -68,13 +71,13 @@ class ColdWeatherPeriodDefaultWidget extends WidgetBase implements WidgetInterfa
     $element['date_start'] = [
       '#type' => 'date',
       '#title' => t('Start date'),
-      '#default_value' => $item->date_start ?? '',
+      '#default_value' => $date_start,
     ];
 
     $element['date_end'] = [
       '#type' => 'date',
       '#title' => t('End date'),
-      '#default_value' => $item->date_end ?? '',
+      '#default_value' => $date_end,
     ];
 
     $stations = $this->entityTypeManager->getStorage('weather_station')->loadMultiple();
@@ -87,7 +90,7 @@ class ColdWeatherPeriodDefaultWidget extends WidgetBase implements WidgetInterfa
       '#type' => 'checkboxes',
       '#title' => t('Weather stations'),
       '#options' => $weather_stations ?? [],
-      '#default_value' => explode(',', $item->stations),
+      '#default_value' => explode(',', $item_stations),
       '#description' => t('Tick the boxes for the weather stations where a cold weather payment was triggered.'),
     ];
 

--- a/nidirect_cold_weather_payments/src/Plugin/Field/FieldWidget/ColdWeatherPeriodDefaultWidget.php
+++ b/nidirect_cold_weather_payments/src/Plugin/Field/FieldWidget/ColdWeatherPeriodDefaultWidget.php
@@ -27,7 +27,7 @@ class ColdWeatherPeriodDefaultWidget extends WidgetBase implements WidgetInterfa
   /**
    * EntityTypeManager.
    *
-   * @var Drupal\Core\Entity\EntityTypeManagerInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
 

--- a/nidirect_cold_weather_payments/src/Plugin/rest/resource/ColdWeatherPaymentResource.php
+++ b/nidirect_cold_weather_payments/src/Plugin/rest/resource/ColdWeatherPaymentResource.php
@@ -24,7 +24,7 @@ class ColdWeatherPaymentResource extends ResourceBase {
   /**
    * Cold Weather Payments service.
    *
-   * @var Drupal\nidirect_cold_weather_payments\Service\ColdWeatherPaymentsService
+   * @var \Drupal\nidirect_cold_weather_payments\Service\ColdWeatherPaymentsService
    */
   protected $paymentsService;
 
@@ -41,7 +41,7 @@ class ColdWeatherPaymentResource extends ResourceBase {
    *   The available serialization formats.
    * @param \Psr\Log\LoggerInterface $logger
    *   A logger instance.
-   * @param Drupal\nidirect_cold_weather_payments\Service\ColdWeatherPaymentsService $payments_service
+   * @param \Drupal\nidirect_cold_weather_payments\Service\ColdWeatherPaymentsService $payments_service
    *   Entity Type Manager instance.
    */
   public function __construct(
@@ -52,7 +52,7 @@ class ColdWeatherPaymentResource extends ResourceBase {
       LoggerInterface $logger,
       ColdWeatherPaymentsService $payments_service
   ) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition, $serializer_formats, $logger, $payments_service);
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $serializer_formats, $logger);
     $this->paymentsService = $payments_service;
   }
 

--- a/nidirect_cold_weather_payments/src/Service/ColdWeatherPaymentsService.php
+++ b/nidirect_cold_weather_payments/src/Service/ColdWeatherPaymentsService.php
@@ -14,7 +14,7 @@ class ColdWeatherPaymentsService {
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  protected $entityTypeManager;
+  protected EntityTypeManagerInterface $entityTypeManager;
 
   /**
    * Cold Weather Payments Service constructor.
@@ -54,6 +54,7 @@ class ColdWeatherPaymentsService {
 
     // Fetch the last revision.
     $vid = array_pop($vid_keys);
+    /** @var \Drupal\node\NodeInterface $node */
     $node = $this->entityTypeManager->getStorage('node')->loadRevision($vid);
 
     // Payment period covered.
@@ -65,6 +66,8 @@ class ColdWeatherPaymentsService {
     // Payment triggers for the period.
     $payment_triggers = $node->get('field_cwp_payments_triggered');
     foreach ($payment_triggers as $trigger) {
+      /** @var \Drupal\Core\Entity\FieldableEntityInterface $trigger */
+
       $payment_granted = FALSE;
       // We need to load each station to extract the postcodes it covers.
       $station_ids = explode(',', $trigger->get('stations')->getValue());
@@ -72,7 +75,9 @@ class ColdWeatherPaymentsService {
 
       $postcodes = [];
       foreach ($stations as $station) {
-        $postcodes = array_merge($postcodes, explode(',', $station->get('postcodes')));
+        /** @var \Drupal\Core\Entity\FieldableEntityInterface $station */
+        $station_postcodes = $station->get('postcodes') ?? '';
+        $postcodes = array_merge($postcodes, explode(',', $station_postcodes));
       }
 
       // Postcodes for stations are stored as the first 2 digits, strip BT

--- a/nidirect_cold_weather_payments/src/WeatherStationEntityListBuilder.php
+++ b/nidirect_cold_weather_payments/src/WeatherStationEntityListBuilder.php
@@ -23,6 +23,7 @@ class WeatherStationEntityListBuilder extends ConfigEntityListBuilder {
    * {@inheritdoc}
    */
   public function buildRow(EntityInterface $entity) {
+    /** @var \Drupal\Core\Entity\FieldableEntityInterface $entity */
     $row['label'] = $entity->label();
     $row['id'] = $entity->get('postcodes');
     return $row + parent::buildRow($entity);

--- a/nidirect_cold_weather_payments/tests/src/Kernel/ColdWeatherPaymentsTest.php
+++ b/nidirect_cold_weather_payments/tests/src/Kernel/ColdWeatherPaymentsTest.php
@@ -46,7 +46,7 @@ class ColdWeatherPaymentsTest extends EntityKernelTestBase {
   /**
    * {@inheritdoc}
    */
-  protected function setUp() {
+  protected function setUp(): void {
     parent::setUp();
 
     $this->installConfig('nidirect_cold_weather_payments');

--- a/nidirect_common/nidirect_common.install
+++ b/nidirect_common/nidirect_common.install
@@ -10,6 +10,7 @@ use Drupal\Core\Link;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\user\Entity\User;
+use Drupal\user\UserInterface;
 
 /**
  * Implements hook_install().
@@ -75,8 +76,9 @@ function nidirect_common_uninstall() {
     // Add prefix from environment var.
     $prefix = getenv('NW_TEST_USER_PREFIX');
     $name = $prefix . $name;
+    /** @var \Drupal\user\UserInterface $user */
     $user = user_load_by_name($name);
-    if (!empty($user)) {
+    if (!$user instanceof UserInterface) {
       \Drupal::logger('nidirect_common')->notice(t('Deleting user @name', ['@name' => $name]));
       $user->delete();
     }
@@ -149,7 +151,12 @@ function nidirect_common_update_8001() {
   // Retrieve and update summary field config for each node type.
   foreach ($field_storage->getBundles() as $id => $label) {
     $field = FieldConfig::loadByName('node', $id, 'field_summary');
-    $field_config = $field->toArray();
+    /** @var \Drupal\field\FieldConfigInterface $field */
+    $field_config = $field->toArray() ?? [];
+
+    if (empty($field_config['field_type'])) {
+      continue;
+    }
 
     if ($field_config['field_type'] === 'text_long') {
       // Change the field type from text_long to string_long.
@@ -242,10 +249,12 @@ function nidirect_common_update_8002() {
     $new_teaser_field['settings']['max_length'] = 255;
 
     $new_teaser_field = FieldStorageConfig::create($new_teaser_field);
-    $new_teaser_field->original = $new_teaser_field;
-    $new_teaser_field->enforceIsNew(FALSE);
+    if (!empty($new_teaser_field->original)) {
+      $new_teaser_field->original = $new_teaser_field;
+      $new_teaser_field->enforceIsNew(FALSE);
 
-    $new_teaser_field->save();
+      $new_teaser_field->save();
+    }
   }
 
   // Restore the original data.

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -60,21 +60,19 @@ function nidirect_common_cron() {
     \Drupal::logger('nidirect-common')->notice(
       'Found @count audit updates to process', ['@count' => $queue->numberOfItems()]
     );
-    if (isset($item) && is_object($item)) {
-      $nid_list_obj = $item->data;
-      if (isset($nid_list_obj) && is_object($nid_list_obj)) {
-        // Convert comma separated list of nids into an array.
-        $nids = explode(",", $nid_list_obj->nids);
-        // Load all nodes at once.
-        $nodes = Node::loadMultiple($nids);
-        foreach ($nodes as $node) {
-          // Double check that auditing is enabled for this content type.
-          if ($node->hasField('field_next_audit_due')) {
-            // Just set next audit date to today as will show in 'needs audit'
-            // report if next audit date is today or earlier.
-            $node->set('field_next_audit_due', $today);
-            $node->save();
-          }
+    $nid_list_obj = $item->data ?? NULL;
+    if (!empty($nid_list_obj) && !empty($nid_list_obj->nids)) {
+      // Convert comma separated list of nids into an array.
+      $nids = explode(",", $nid_list_obj->nids);
+      // Load all nodes at once.
+      $nodes = Node::loadMultiple($nids);
+      foreach ($nodes as $node) {
+        // Double check that auditing is enabled for this content type.
+        if ($node->hasField('field_next_audit_due')) {
+          // Just set next audit date to today as will show in 'needs audit'
+          // report if next audit date is today or earlier.
+          $node->set('field_next_audit_due', $today);
+          $node->save();
         }
       }
     }
@@ -90,7 +88,7 @@ function nidirect_common_cron() {
  */
 function nidirect_common_entity_presave(EntityInterface $entity) {
   // This will fire when nodes are created or edited.
-  if ($entity->getEntityTypeId() == 'node') {
+  if ($entity instanceof NodeInterface) {
     /*
      * Programmatically sets the field_top_level_theme based on
      * the parent taxonomy tids of the field_subtheme value.
@@ -114,7 +112,7 @@ function nidirect_common_entity_presave(EntityInterface $entity) {
  * Implements hook_views_pre_render().
  */
 function nidirect_common_views_pre_render(ViewExecutable $view) {
-  if ($view->id() == 'publications' && $view->current_display == 'search_page') {
+  if ($view->id() === 'publications' && $view->current_display === 'search_page') {
     if (!empty($view->header['area'])) {
       $item_count = $view->pager->total_items ?? 0;
       // Generate the header content to show N publication(s).
@@ -132,9 +130,9 @@ function nidirect_common_views_pre_render(ViewExecutable $view) {
  * Implements hook_ENTITY_TYPE_view().
  */
 function nidirect_common_node_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
-
+  /** @var \Drupal\node\NodeInterface $entity */
   // Override misleading layout builder notice.
-  if ($entity->bundle() == 'landing_page') {
+  if ($entity->bundle() === 'landing_page') {
     // (Layout builder is only used on landing pages for now, this
     // may be expanded to other content types later.)
     $messages = \Drupal::messenger()->messagesByType('status');
@@ -179,6 +177,7 @@ function nidirect_common_node_view(array &$build, EntityInterface $entity, Entit
  * Invalidate taxonomy cache tags after node save.
  */
 function nidirect_common_node_presave(EntityInterface $entity) {
+  /** @var \Drupal\node\NodeInterface $entity */
   // Check that the node is published.
   if ($entity->get('status')->value) {
     $cache_service = \Drupal::service('nidirect_common.invalidate_taxonomy_list_cache_tags');
@@ -200,9 +199,10 @@ function nidirect_common_node_delete(EntityInterface $entity) {
  * Implements hook_ENTITY_TYPE_presave() for taxonomy_term entities.
  */
 function nidirect_common_taxonomy_term_presave(EntityInterface $entity) {
+  /** @var \Drupal\taxonomy\TermInterface $entity */
   // Invalidate 'taxonomy_term_list' custom cache tag for the
   // parent when a new taxonomy term is created.
-  if ($entity->get('vid')->target_id == 'site_themes') {
+  if ($entity->get('vid')->target_id ?? '' === 'site_themes') {
     if ($entity->isNewRevision()) {
       $parent = $entity->get('parent')->target_id;
       if ($parent) {
@@ -328,7 +328,7 @@ function nidirect_common_shs_js_settings_alter(&$settings_shs, $bundle, $field_n
  *   Value for the field, it there is one.
  */
 function _retrieve_hierarchical_field(EntityInterface $entity, string $field) {
-
+  /** @var \Drupal\Core\Entity\FieldableEntityInterface $entity */
   $field_value = NULL;
 
   // Fetch the image banner if the current entity has one.
@@ -341,18 +341,20 @@ function _retrieve_hierarchical_field(EntityInterface $entity, string $field) {
   // own banner. If we're dealing with a term, assign directly.
   // Finally try to extract a banner image from the term.
   if (empty($field_value)) {
+    $term = NULL;
+
     if ($entity instanceof Node && $entity->hasField('field_subtheme') && $entity->bundle() !== 'landing_page') {
-      $term = $entity->get('field_subtheme')->entity;
+      $term = $entity->get('field_subtheme')->entity ?? NULL;
 
       if (empty($term)) {
-        return;
+        return NULL;
       }
     }
     elseif ($entity instanceof Term) {
       $term = $entity;
     }
 
-    if (!empty($term)) {
+    if ($term instanceof TermInterface) {
       if ($term->hasField($field) && !$term->get($field)->isEmpty()) {
         $field_value = $term->get($field)->first();
       }
@@ -556,6 +558,7 @@ function nidirect_common_page_attachments(array &$page) {
         $all_themes[] = $term->label();
       }
 
+      $datalayer_values = [];
       if (!empty($all_themes)) {
         // Reverse order of themes.
         $all_themes = array_reverse($all_themes);

--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -324,7 +324,7 @@ function nidirect_common_shs_js_settings_alter(&$settings_shs, $bundle, $field_n
  * @param string $field
  *   Machine name of the field to lookup.
  *
- * @return string|null
+ * @return \Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem|null
  *   Value for the field, it there is one.
  */
 function _retrieve_hierarchical_field(EntityInterface $entity, string $field) {

--- a/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
+++ b/nidirect_common/src/InvalidateTaxonomyListCacheTags.php
@@ -44,6 +44,7 @@ class InvalidateTaxonomyListCacheTags {
    * Invalidate custom cache tags for this entity.
    */
   public function invalidateForEntity(EntityInterface $entity) {
+    /** @var \Drupal\taxonomy\TermInterface $entity */
     // If a node references any point in the 'site themes'
     // vocabulary, make sure that the appropriate taxonomy
     // cache tags are invalidated.
@@ -61,8 +62,10 @@ class InvalidateTaxonomyListCacheTags {
         }
         // If this is an update, invalidate cache tag for
         // original taxonomy term as well.
-        if ($entity->original instanceof NodeInterface) {
-          $tid = $entity->original->get($thisfield)->target_id;
+        /** @var \Drupal\Core\Entity\ContentEntityInterface $original */
+        $original = $entity->original ?? '';
+        if ($original instanceof NodeInterface) {
+          $tid = $original->get($thisfield)->target_id ?? 0;
           if (!empty($tid)) {
             $taxonomy_tags[] = 'taxonomy_term_list:' . $tid;
             $parent_tid = $this->checkLandingPageParent($entity, $tid);
@@ -84,8 +87,9 @@ class InvalidateTaxonomyListCacheTags {
    * Get parent taxonomy term for landing pages.
    */
   private function checkLandingPageParent(EntityInterface $entity, int $tid) {
+    /** @var \Drupal\taxonomy\TermInterface $entity */
     // Landing page is a special case.
-    if ($entity->type->target_id == 'landing_page') {
+    if ($entity->get('type')->target_id === 'landing_page') {
       // In this case we want to invalidate the cache tag for
       // the parent of the current term.
       $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($tid);

--- a/nidirect_common/src/LinkitSuggestionManager.php
+++ b/nidirect_common/src/LinkitSuggestionManager.php
@@ -44,7 +44,7 @@ class LinkitSuggestionManager extends SuggestionManager {
     // Display for empty searches.
     if (empty(trim($search_string))) {
       $suggestion = new DescriptionSuggestion();
-      $suggestion->setLabek($this->t('No content results'));
+      $suggestion->setLabel($this->t('No content results'));
       $suggestion->setDescription($this->t('Please enter search terms'));
 
       $suggestions->addSuggestion($suggestion);

--- a/nidirect_common/src/Plugin/Field/FieldFormatter/AncestralValueFieldFormatter.php
+++ b/nidirect_common/src/Plugin/Field/FieldFormatter/AncestralValueFieldFormatter.php
@@ -156,7 +156,12 @@ class AncestralValueFieldFormatter extends FormatterBase implements ContainerFac
         // Navigate the configured depth of ancestor terms.
         for ($i = 0; $i < $settings['ancestor_depth']; $i++) {
           if (array_key_exists($i, $ancestors)) {
+            /** @var \Drupal\Core\Field\FieldItemListInterface $field */
             $field = $ancestors[$i]->get('field_additional_info');
+            // Ignore below phpstan issue: unclear what specific class
+            // or interface should be set to access a field iterator.
+            // Call to an undefined method Drupal\Core\Field\FieldItemListInterface::getIterator().
+            // @phpstan-ignore-next-line.
             $items = $field->getIterator();
 
             if ($items->count()) {

--- a/nidirect_contacts/nidirect_contacts.module
+++ b/nidirect_contacts/nidirect_contacts.module
@@ -38,7 +38,8 @@ function nidirect_contacts_form_views_exposed_form_alter(&$form, FormStateInterf
  * Implements hook_views_query_alter().
  */
 function nidirect_contacts_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
-  if ($view->id() == 'contacts_a_z' && $view->current_display == 'contacts_by_letter') {
+  if ($view->id() === 'contacts_a_z' && $view->current_display === 'contacts_by_letter') {
+    /** @var \Drupal\views\Plugin\views\query\Sql $query */
     // The search letter is passed in via a Contextual argument against the
     // title field.
     $letter = $query->where[0]['conditions'][0]['value'];
@@ -257,15 +258,21 @@ function nidirect_contacts_views_pre_render(ViewExecutable $view) {
 
     $results = &$view->result;
     foreach ($results as $key => &$result) {
+      /** @var \Drupal\views\ResultRow $result */
       // If the current result doesn't start with the search letter it's been
       // added to the results because we have a match with the Supplementary
       // contact. Extract that Supplementary title and replace the entity
       // result title. We also update the node_field_data_title so we can
       // extract an array of titles for sorting the results.
-      if (strtolower(substr($result->node_field_data_title, 0, 1)) !== $search_letter) {
-        $node_title = $result->_entity->field_supplementary_contact->getString();
-        $results[$key]->node_field_data_title = $node_title;
-        $result->_entity->setTitle($node_title);
+      if (strtolower(substr($result->node_field_data_title ?? '', 0, 1)) !== $search_letter) {
+        /** @var \Drupal\node\NodeInterface $supplementary_contact */
+        $supplementary_contact = $result->_entity->get('field_supplementary_contact');
+        $node_title = $supplementary_contact->label();
+
+        $result->node_field_data_title = $node_title;
+        /** @var \Drupal\node\NodeInterface $node */
+        $node = $result->_entity;
+        $node->setTitle($node_title);
       }
     }
 

--- a/nidirect_contacts/nidirect_contacts.module
+++ b/nidirect_contacts/nidirect_contacts.module
@@ -265,11 +265,17 @@ function nidirect_contacts_views_pre_render(ViewExecutable $view) {
       // result title. We also update the node_field_data_title so we can
       // extract an array of titles for sorting the results.
       if (strtolower(substr($result->node_field_data_title ?? '', 0, 1)) !== $search_letter) {
-        /** @var \Drupal\node\NodeInterface $supplementary_contact */
-        $supplementary_contact = $result->_entity->get('field_supplementary_contact');
-        $node_title = $supplementary_contact->label();
+        /** @var \Drupal\node\NodeInterface $entity */
+        $entity = $result->_entity;
+        $supplementary_contact = $entity->get('field_supplementary_contact');
+        $node_title = $supplementary_contact->getString();
 
+        // Ignore next phpstan error; no appropriate setting function
+        // on the public properties the ResultRow object contains.
+
+        // @phpstan-ignore-next-line.
         $result->node_field_data_title = $node_title;
+
         /** @var \Drupal\node\NodeInterface $node */
         $node = $result->_entity;
         $node->setTitle($node_title);

--- a/nidirect_contacts/src/Controller/ContactListingController.php
+++ b/nidirect_contacts/src/Controller/ContactListingController.php
@@ -31,7 +31,7 @@ class ContactListingController extends ControllerBase {
   /**
    * Symfony\Component\HttpFoundation\RequestStack definition.
    *
-   * @var Symfony\Component\HttpFoundation\RequestStack
+   * @var \Symfony\Component\HttpFoundation\RequestStack
    */
   protected $request;
 

--- a/nidirect_contacts/src/Plugin/Block/ContactAzBlock.php
+++ b/nidirect_contacts/src/Plugin/Block/ContactAzBlock.php
@@ -21,7 +21,7 @@ class ContactAzBlock extends BlockBase implements ContainerFactoryPluginInterfac
   /**
    * Drupal\Core\Routing\CurrentRouteMatch definition.
    *
-   * @var Drupal\Core\Routing\CurrentRouteMatch
+   * @var \Drupal\Core\Routing\CurrentRouteMatch
    */
   protected $routeMatch;
 
@@ -34,7 +34,7 @@ class ContactAzBlock extends BlockBase implements ContainerFactoryPluginInterfac
    *   The plugin id.
    * @param mixed $plugin_definition
    *   Plugin definition.
-   * @param Drupal\Core\Routing\CurrentRouteMatch $route_match
+   * @param \Drupal\Core\Routing\CurrentRouteMatch $route_match
    *   Route match object.
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, CurrentRouteMatch $route_match) {
@@ -64,7 +64,7 @@ class ContactAzBlock extends BlockBase implements ContainerFactoryPluginInterfac
 
     $title = $this->t('Find contacts beginning with<span class="visually-hidden"> A to Z</span>...');
 
-    if ($this->routeMatch->getRouteName() == 'nidirect_contacts.letter') {
+    if ($this->routeMatch->getRouteName() === 'nidirect_contacts.letter') {
       $letter = $this->routeMatch->getParameter('letter');
       $title = $this->t('Showing entries for :letter', [':letter' => strtoupper($letter)]);
       $skip_link = '<a href="#contact-links" class="skip-link visually-hidden focusable">';

--- a/nidirect_contacts/src/Plugin/Field/FieldFormatter/NIDirectTelephoneLinkFormatter.php
+++ b/nidirect_contacts/src/Plugin/Field/FieldFormatter/NIDirectTelephoneLinkFormatter.php
@@ -25,6 +25,7 @@ class NIDirectTelephoneLinkFormatter extends TelephonePlusLinkFormatter {
 
   /**
    * {@inheritdoc}
+   * @throws \Drupal\Core\TypedData\Exception\MissingDataException
    */
   public function viewElements(FieldItemListInterface $items, $langcode) {
     $elements = parent::viewElements($items, $langcode);
@@ -33,9 +34,9 @@ class NIDirectTelephoneLinkFormatter extends TelephonePlusLinkFormatter {
     $formatting_chars = [' ', '+'];
 
     foreach ($items as $item) {
-      /** @var \Drupal\Core\Field\FieldItemList $item */
-      $telephone_value = $item->getValue('telephone_number');
-      $unformatted_field_number = str_replace($formatting_chars, '', $telephone_value['telephone_number']);
+      /** @var \Drupal\Core\Field\Plugin\Field\FieldType\StringItem $item */
+      $telephone_value = $item->telephone_number ?? '';
+      $unformatted_field_number = str_replace($formatting_chars, '', $telephone_value);
       // Match international and textphone numbers to replace the default
       // formatting provided by the libphonenumber library.
       if (strpos($unformatted_field_number, '00800') === 0 || strpos($unformatted_field_number, '18001') === 0) {
@@ -46,7 +47,7 @@ class NIDirectTelephoneLinkFormatter extends TelephonePlusLinkFormatter {
             // Check the source value contains the prefix as some contacts use
             // the same number for phone and text phone.
             if (strpos($element['number']['#value'], '00800') === 0 || strpos($element['number']['#value'], '18001') === 0) {
-              $element['number']['#value'] = $telephone_value['telephone_number'];
+              $element['number']['#value'] = $telephone_value;
             }
           }
         }

--- a/nidirect_contacts/src/Plugin/Field/FieldFormatter/NIDirectTelephoneLinkFormatter.php
+++ b/nidirect_contacts/src/Plugin/Field/FieldFormatter/NIDirectTelephoneLinkFormatter.php
@@ -33,7 +33,9 @@ class NIDirectTelephoneLinkFormatter extends TelephonePlusLinkFormatter {
     $formatting_chars = [' ', '+'];
 
     foreach ($items as $item) {
-      $unformatted_field_number = str_replace($formatting_chars, '', $item->getValue('telephone_number')['telephone_number']);
+      /** @var \Drupal\Core\Field\FieldItemList $item */
+      $telephone_value = $item->getValue('telephone_number');
+      $unformatted_field_number = str_replace($formatting_chars, '', $telephone_value['telephone_number']);
       // Match international and textphone numbers to replace the default
       // formatting provided by the libphonenumber library.
       if (strpos($unformatted_field_number, '00800') === 0 || strpos($unformatted_field_number, '18001') === 0) {
@@ -44,7 +46,7 @@ class NIDirectTelephoneLinkFormatter extends TelephonePlusLinkFormatter {
             // Check the source value contains the prefix as some contacts use
             // the same number for phone and text phone.
             if (strpos($element['number']['#value'], '00800') === 0 || strpos($element['number']['#value'], '18001') === 0) {
-              $element['number']['#value'] = $item->getValue('telephone_number')['telephone_number'];
+              $element['number']['#value'] = $telephone_value['telephone_number'];
             }
           }
         }

--- a/nidirect_dblog/nidirect_dblog.module
+++ b/nidirect_dblog/nidirect_dblog.module
@@ -8,6 +8,7 @@
  */
 
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\redirect\Entity\Redirect;
 
 /**
  * Implements hook_entity_delete().
@@ -16,7 +17,7 @@ use Drupal\Core\Entity\EntityInterface;
  */
 function nidirect_dblog_entity_delete(EntityInterface $entity) {
   // Are we deleting a redirect entity ?
-  if ($entity->bundle() == 'redirect') {
+  if ($entity instanceof Redirect) {
     // Extract the redirect destination details from the
     // string in the format 'internal:/node/nnnn'.
     $destination = $entity->getRedirect()['uri'];
@@ -25,7 +26,10 @@ function nidirect_dblog_entity_delete(EntityInterface $entity) {
     // Get the node alias for extra info.
     $alias = \Drupal::service('path_alias.manager')->getAliasByPath($destination);
     // Get the redirect source.
-    $source = $entity->get('redirect_source')->get(0)->getUrl()->toString();
+    /** @var \Drupal\redirect\Plugin\Field\FieldType\RedirectSourceItem $redirect_source */
+    $redirect_source = $entity->get('redirect_source')->get(0);
+    $source = $redirect_source->getUrl()->toString();
+
     // Track the current user.
     $username = \Drupal::currentUser()->getAccountName();
     $message = t("Redirect from @source to @alias (nid @nid) deleted by @username",

--- a/nidirect_driving_instructors/nidirect_driving_instructors.module
+++ b/nidirect_driving_instructors/nidirect_driving_instructors.module
@@ -9,6 +9,7 @@ use Drupal\Component\Utility\Html;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
 use Drupal\search_api\Query\QueryInterface;
 use Drupal\views\ViewExecutable;
 use Drupal\Component\Utility\Xss;
@@ -145,16 +146,14 @@ function nidirect_driving_instructors_after_build($form, &$form_state) {
  */
 function nidirect_driving_instructors_entity_presave(EntityInterface $entity) {
   // This will fire when nodes are created or edited.
-  if ($entity->getEntityTypeId() == 'node') {
+  if ($entity instanceof NodeInterface && $entity->bundle() === 'driving_instructor') {
     // Construct the node title for driving instructors based
     // on name and ADI number.
-    if ($entity->bundle() == 'driving_instructor') {
-      $forename = Xss::filter($entity->get('field_di_firstname')->value);
-      $surname = Xss::filter($entity->get('field_di_lastname')->value);
-      $adi = Xss::filter($entity->get('field_di_adi_no')->value);
-      $title = $forename . ' ' . $surname . ' (ADI No. ' . $adi . ')';
-      $entity->setTitle($title);
-    }
+    $forename = Xss::filter($entity->get('field_di_firstname')->value);
+    $surname = Xss::filter($entity->get('field_di_lastname')->value);
+    $adi = Xss::filter($entity->get('field_di_adi_no')->value);
+    $title = $forename . ' ' . $surname . ' (ADI No. ' . $adi . ')';
+    $entity->setTitle($title);
   }
 }
 

--- a/nidirect_driving_instructors/tests/src/Functional/DrivingInstructorTest.php
+++ b/nidirect_driving_instructors/tests/src/Functional/DrivingInstructorTest.php
@@ -32,7 +32,7 @@ class DrivingInstructorTest extends BrowserTestBase {
   /**
    * Use install profile so that we have all content types, modules etc.
    *
-   * @var installprofile
+   * @var string
    */
   protected $profile = 'test_profile';
 

--- a/nidirect_driving_instructors/tests/src/Kernel/DrivingInstructorTest.php
+++ b/nidirect_driving_instructors/tests/src/Kernel/DrivingInstructorTest.php
@@ -28,9 +28,9 @@ class DrivingInstructorTest extends EntityKernelTestBase {
   ];
 
   /**
-   * Test setup function.
+   * {@inheritdoc}
    */
-  public function setUp() {
+  public function setUp(): void {
     parent::setUp();
 
     $this->installConfig('nidirect_driving_instructors');

--- a/nidirect_gp/nidirect_gp.module
+++ b/nidirect_gp/nidirect_gp.module
@@ -5,6 +5,7 @@
  * Contains nidirect_gp.module.
  */
 
+use Drupal\node\NodeInterface;
 use Drupal\views\Views;
 use Drupal\Component\Utility\Xss;
 use Drupal\Core\Entity\EntityInterface;
@@ -49,15 +50,16 @@ function nidirect_gp_node_view(array &$build, EntityInterface $entity, LayoutBui
   if (array_key_exists('gp_names', $display->getComponents())) {
     $gp_names = [];
 
+    /** @var \Drupal\node\NodeInterface $entity */
     // Lead GP.
-    if (!empty($entity->field_gp_practice_lead->referencedEntities())) {
-      $gp = $entity->field_gp_practice_lead->referencedEntities()[0];
+    if (!empty($entity->get('field_gp_practice_lead')->referencedEntities())) {
+      $gp = $entity->get('field_gp_practice_lead')->referencedEntities()[0];
       $gp_names[] = $gp->label();
     }
 
     // Member GPs.
-    if (!empty($entity->field_gp_practice_member->referencedEntities())) {
-      foreach ($entity->field_gp_practice_member->referencedEntities() as $index => $gp) {
+    if (!empty($entity->get('field_gp_practice_member')->referencedEntities())) {
+      foreach ($entity->get('field_gp_practice_member')->referencedEntities() as $index => $gp) {
         $gp_names[] = $gp->label();
       }
     }
@@ -235,21 +237,13 @@ function nidirect_gp_gp_practice_form_submit(&$form, FormStateInterface $form_st
  */
 function nidirect_gp_entity_presave(EntityInterface $entity) {
   // This will fire when nodes are created or edited.
-  if ($entity->getEntityTypeId() != 'node') {
-    return;
+  if ($entity instanceof NodeInterface && $entity->bundle() === 'gp_practice') {
+    // Construct the title.
+    $practice = Xss::filter($entity->get('field_gp_practice_name')->value);
+    $surgery = Xss::filter($entity->get('field_gp_surgery_name')->value);
+    $title = _build_gp_practice_title($practice, $surgery);
+    $entity->setTitle($title);
   }
-
-  if ($entity->bundle() != 'gp_practice') {
-    return;
-  }
-
-  // Construct the title.
-  $practice = Xss::filter($entity->get('field_gp_practice_name')->value);
-  $surgery = Xss::filter($entity->get('field_gp_surgery_name')->value);
-
-  $title = _build_gp_practice_title($practice, $surgery);
-
-  $entity->setTitle($title);
 }
 
 /**
@@ -278,7 +272,10 @@ function nidirect_gp_preprocess_views_view_field(&$variables) {
     $gp_ids = $variables['field']->getValue($variables['row']);
     $gps = \Drupal::entityTypeManager()->getStorage('gp')->loadMultiple($gp_ids);
 
+    $list_items = [];
+
     foreach ($gps as $gp) {
+      /** @var \Drupal\nidirect_gp\Entity\GpInterface $gp */
       $list_items[$gp->id()]['#markup'] = $gp->getDisplayName() . " [" . $gp->getCypher() . "] " . $gp->toLink('Edit')->toString();
     }
 
@@ -308,6 +305,7 @@ function _build_gp_practice_title($practiceName = '', $surgeryName = '') {
   4. Neither provided
    */
 
+  $title = '';
   // 1. Both provided.
   if ($practiceName != '' && $surgeryName != '') {
     $title = $surgeryName . ' - ' . $practiceName;
@@ -338,16 +336,15 @@ function nidirect_gp_views_query_alter(ViewExecutable $view, QueryPluginBase $qu
   // of sorting on a 'link' field as it does not build the join correctly
   // and just errors on the 'unknown' field that appears in the 'orderby'.
   if ($view->id() == 'gp_practice_list') {
-    if (isset($query->orderby)
-      && is_array($query->orderby)
-      && isset($query->orderby[0])
-      && isset($query->orderby[0]['field'])) {
-      if ($query->orderby[0]['field'] == 'unknown') {
+    $query_order = $query->orderby ?? NULL;
+
+    if (!empty($query_order) && !empty($query_order[0]) && !empty($query_order[0]['field'])) {
+      if ($query_order[0]['field'] === 'unknown') {
         // Decide whether we are sorting by the 'Online appointments' column or
         // by 'Online precriptions'.
         $join_table = NULL;
         $view_input = $view->getExposedInput();
-        if (isset($view_input) && isset($view_input['order'])) {
+        if (!empty($view_input['order'])) {
           if ($view_input['order'] == 'nothing') {
             // We are sorting by 'Online appointments'.
             $join_table = 'node__field_gp_appointments';
@@ -373,7 +370,9 @@ function nidirect_gp_views_query_alter(ViewExecutable $view, QueryPluginBase $qu
         // is an entry in the joined table for each practice.
         $join_obj = Views::pluginManager('join')
           ->createInstance('standard', $configuration);
-        $rel = $query->addRelationship($join_table, $join_obj, 'node_field_data');
+
+        /** @var \Drupal\views\Plugin\views\query\Sql $query */
+        $query->addRelationship($join_table, $join_obj, 'node_field_data');
         // Replace the 'unknown' field in the query 'orderby' with the
         // correct field.
         if ($join_table == 'node__field_gp_appointments') {

--- a/nidirect_gp/src/Controller/GpController.php
+++ b/nidirect_gp/src/Controller/GpController.php
@@ -60,7 +60,7 @@ class GpController extends ControllerBase {
   }
 
   /**
-   * Page title callback for a GP  revision.
+   * Page title callback for a GP revision.
    *
    * @param int $gp_revision
    *   The GP  revision ID.
@@ -68,8 +68,10 @@ class GpController extends ControllerBase {
    * @return string
    *   The page title.
    */
-  public function revisionPageTitle($gp_revision) {
+  public function revisionPageTitle(int $gp_revision) {
+    /** @var \Drupal\nidirect_gp\Entity\Gp $gp */
     $gp = $this->entityTypeManager()->getStorage('gp')->loadRevision($gp_revision);
+
     return $this->t('Revision of %title from %date', [
       '%title' => $gp->label(),
       '%date' => $this->dateFormatter->format($gp->getRevisionCreationTime()),
@@ -91,6 +93,8 @@ class GpController extends ControllerBase {
     $langname = $gp->language()->getName();
     $languages = $gp->getTranslationLanguages();
     $has_translations = (count($languages) > 1);
+
+    /** @var \Drupal\nidirect_gp\GpStorageInterface $gp_storage */
     $gp_storage = $this->entityTypeManager()->getStorage('gp');
 
     $build['#title'] = $has_translations ? $this->t('@langname revisions for %title', [
@@ -108,7 +112,7 @@ class GpController extends ControllerBase {
     $latest_revision = TRUE;
 
     foreach (array_reverse($vids) as $vid) {
-      /** @var \Drupal\nidirect_gp\GpInterface $revision */
+      /** @var \Drupal\nidirect_gp\Entity\Gp $revision */
       $revision = $gp_storage->loadRevision($vid);
       // Only show revisions that are affected by the language that is being
       // displayed.
@@ -118,7 +122,7 @@ class GpController extends ControllerBase {
           '#account' => $revision->getRevisionUser(),
         ];
 
-        // Use revision link to link to revisions that are not active.
+        // Use revision link to revisions that are not active.
         $date = $this->dateFormatter->format($revision->getRevisionCreationTime(), 'short');
         if ($vid != $gp->getRevisionId()) {
           $link = Link::fromTextAndUrl($date, new Url('entity.gp.revision', [

--- a/nidirect_gp/src/Controller/GpSearchController.php
+++ b/nidirect_gp/src/Controller/GpSearchController.php
@@ -9,6 +9,7 @@ use Drupal\Core\Form\FormState;
 use Drupal\geocoder\GeocoderInterface;
 use Drupal\nidirect_gp\PostcodeExtractor;
 use Drupal\views\ViewExecutable;
+use Geocoder\Model\AddressCollection;
 use maxh\Nominatim\Exceptions\NominatimException;
 use maxh\Nominatim\Nominatim;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -73,7 +74,7 @@ class GpSearchController extends ControllerBase {
   /**
    * Drupal Form Builder.
    *
-   * @var \Drupal\core\Form\FormBuilderInterface
+   * @var \Drupal\Core\Form\FormBuilderInterface
    */
   protected $formBuilder;
 
@@ -97,7 +98,7 @@ class GpSearchController extends ControllerBase {
    *   Max distance in miles for geocoding radius.
    * @param string $geocoding_service_id
    *   Geocoding service ID.
-   * @param \Drupal\core\Form\FormBuilderInterface $form_builder
+   * @param \Drupal\Core\Form\FormBuilderInterface $form_builder
    *   Form builder.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   Entity type manager.
@@ -209,7 +210,7 @@ class GpSearchController extends ControllerBase {
         // Geocode the first postcode (only accept single values for search).
         $geocode_task_results = $this->geocoder->geocode($search_type['postcode'][0], $provider);
 
-        if (!empty(($geocode_task_results))) {
+        if ($geocode_task_results instanceof AddressCollection) {
           $geocode_coordinates = $geocode_task_results->first()->getCoordinates();
           $this->latitude = $geocode_coordinates->getLatitude();
           $this->longitude = $geocode_coordinates->getLongitude();
@@ -367,7 +368,7 @@ class GpSearchController extends ControllerBase {
       $result = $nominatim->find($reverse);
     }
     catch (NominatimException $e) {
-      $this->getLogger()->error($e);
+      $this->getLogger('nidirect_gp')->error($e);
       return $locality;
     }
 

--- a/nidirect_gp/src/Entity/Gp.php
+++ b/nidirect_gp/src/Entity/Gp.php
@@ -123,6 +123,7 @@ class Gp extends RevisionableContentEntityBase implements GpInterface {
     parent::preSave($storage);
 
     foreach (array_keys($this->getTranslationLanguages()) as $langcode) {
+      /** @var \Drupal\nidirect_gp\Entity\Gp $translation */
       $translation = $this->getTranslation($langcode);
 
       // If no owner has been set explicitly, make the anonymous user the owner.

--- a/nidirect_gp/src/EventSubscriber/GeocoderApiKeyUpdate.php
+++ b/nidirect_gp/src/EventSubscriber/GeocoderApiKeyUpdate.php
@@ -18,14 +18,14 @@ class GeocoderApiKeyUpdate implements EventSubscriberInterface {
   /**
    * The upadte config from env service.
    *
-   * @var Drupal\nidirect_common\UpdateConfigFromEnvironment
+   * @var \Drupal\nidirect_common\UpdateConfigFromEnvironment
    */
   protected $updateEnvService;
 
   /**
    * Constructs a new GeocoderApiKeyUpdate instance.
    *
-   * @param Drupal\nidirect_common\UpdateConfigFromEnvironment $update_service
+   * @param \Drupal\nidirect_common\UpdateConfigFromEnvironment $update_service
    *   The entity type manager.
    */
   public function __construct(UpdateConfigFromEnvironment $update_service) {

--- a/nidirect_gp/src/Form/GpForm.php
+++ b/nidirect_gp/src/Form/GpForm.php
@@ -48,12 +48,11 @@ class GpForm extends ContentEntityForm {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    /**
-     * @var \Drupal\nidirect_gp\Entity\Gp $entity
-     */
     $form = parent::buildForm($form, $form_state);
 
-    if (!$this->entity->isNew()) {
+    /** @var \Drupal\nidirect_gp\Entity\Gp $entity */
+    $entity = $this->entity;
+    if (!$entity->isNew()) {
       $form['new_revision'] = [
         '#type' => 'checkbox',
         '#title' => $this->t('Create new revision'),
@@ -61,8 +60,6 @@ class GpForm extends ContentEntityForm {
         '#weight' => 10,
       ];
     }
-
-    $entity = $this->entity;
 
     return $form;
   }
@@ -99,8 +96,10 @@ class GpForm extends ContentEntityForm {
           '%label' => $entity->label(),
         ]));
     }
-    // $form_state->setRedirect('entity.gp.canonical', ['gp' => $entity->id()]);
+
     $form_state->setRedirect('entity.gp.collection');
+
+    return $status;
   }
 
 }

--- a/nidirect_gp/src/Form/GpRevisionRevertForm.php
+++ b/nidirect_gp/src/Form/GpRevisionRevertForm.php
@@ -41,16 +41,26 @@ class GpRevisionRevertForm extends ConfirmFormBase {
   protected $dateFormatter;
 
   /**
+   * Messenger service object.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
    * Constructs a new GpRevisionRevertForm.
    *
    * @param \Drupal\Core\Entity\EntityStorageInterface $entity_storage
    *   The GP storage.
    * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
    *   The date formatter service.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   Messenger service object.
    */
-  public function __construct(EntityStorageInterface $entity_storage, DateFormatterInterface $date_formatter) {
+  public function __construct(EntityStorageInterface $entity_storage, DateFormatterInterface $date_formatter, MessengerInterface $messenger) {
     $this->gpStorage = $entity_storage;
     $this->dateFormatter = $date_formatter;
+    $this->messenger = $messenger;
   }
 
   /**
@@ -59,7 +69,8 @@ class GpRevisionRevertForm extends ConfirmFormBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('entity_type.manager')->getStorage('gp'),
-      $container->get('date.formatter')
+      $container->get('date.formatter'),
+      $container->get('messenger')
     );
   }
 
@@ -124,7 +135,7 @@ class GpRevisionRevertForm extends ConfirmFormBase {
       '%title' => $this->revision->label(),
       '%revision' => $this->revision->getRevisionId(),
     ]);
-    MessengerInterface::addMessage(t('GP %title has been reverted to the revision from %revision-date.', [
+    $this->messenger->addMessage(t('GP %title has been reverted to the revision from %revision-date.', [
       '%title' => $this->revision->label(),
       '%revision-date' => $this->dateFormatter->format($original_revision_timestamp),
     ]));

--- a/nidirect_gp/src/Form/GpRevisionRevertTranslationForm.php
+++ b/nidirect_gp/src/Form/GpRevisionRevertTranslationForm.php
@@ -6,6 +6,7 @@ use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\nidirect_gp\Entity\GpInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -40,9 +41,11 @@ class GpRevisionRevertTranslationForm extends GpRevisionRevertForm {
    *   The date formatter service.
    * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
    *   The language manager.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   Messenger service object.
    */
-  public function __construct(EntityStorageInterface $entity_storage, DateFormatterInterface $date_formatter, LanguageManagerInterface $language_manager) {
-    parent::__construct($entity_storage, $date_formatter);
+  public function __construct(EntityStorageInterface $entity_storage, DateFormatterInterface $date_formatter, LanguageManagerInterface $language_manager, MessengerInterface $messenger) {
+    parent::__construct($entity_storage, $date_formatter, $messenger);
     $this->languageManager = $language_manager;
   }
 
@@ -53,7 +56,8 @@ class GpRevisionRevertTranslationForm extends GpRevisionRevertForm {
     return new static(
       $container->get('entity_type.manager')->getStorage('gp'),
       $container->get('date.formatter'),
-      $container->get('language_manager')
+      $container->get('language_manager'),
+      $container->get('messenger')
     );
   }
 
@@ -96,7 +100,7 @@ class GpRevisionRevertTranslationForm extends GpRevisionRevertForm {
   protected function prepareRevertedRevision(GpInterface $revision, FormStateInterface $form_state) {
     $revert_untranslated_fields = $form_state->getValue('revert_untranslated_fields');
 
-    /** @var \Drupal\nidirect_gp\Entity\GpInterface $default_revision */
+    /** @var \Drupal\nidirect_gp\Entity\GpInterface $latest_revision */
     $latest_revision = $this->gpStorage->load($revision->id());
     $latest_revision_translation = $latest_revision->getTranslation($this->langcode);
 

--- a/nidirect_gp/src/GpAutocompleteMatcher.php
+++ b/nidirect_gp/src/GpAutocompleteMatcher.php
@@ -51,7 +51,7 @@ class GpAutocompleteMatcher extends EntityAutocompleteMatcher {
 
     $handler = $this->selectionManager->getInstance($options);
 
-    if (isset($string)) {
+    if (!empty($string) && !empty($handler)) {
       $match_operator = !empty($selection_settings['match_operator']) ? $selection_settings['match_operator'] : 'CONTAINS';
       $entity_labels = $handler->getReferenceableEntities($string, $match_operator, 30);
 
@@ -60,6 +60,7 @@ class GpAutocompleteMatcher extends EntityAutocompleteMatcher {
           $entity = $this->entityTypeManager->getStorage($target_type)->load($id);
 
           $key = $label . ' (' . $id . ')';
+          /** @var \Drupal\nidirect_gp\Entity\Gp $entity */
           $label .= ' [GP cypher: ' . $entity->getCypher() . '] (' . $id . ')';
           $key = Html::decodeEntities($key);
           $matches[] = ['value' => $key, 'label' => $label];

--- a/nidirect_gp/src/GpHtmlRouteProvider.php
+++ b/nidirect_gp/src/GpHtmlRouteProvider.php
@@ -69,8 +69,9 @@ class GpHtmlRouteProvider extends AdminHtmlRouteProvider {
         ->setRequirement('_permission', 'access gp revisions')
         ->setOption('_admin_route', TRUE);
 
-      return $route;
     }
+
+    return $route ?? NULL;
   }
 
   /**
@@ -92,9 +93,9 @@ class GpHtmlRouteProvider extends AdminHtmlRouteProvider {
         ])
         ->setRequirement('_permission', 'access gp revisions')
         ->setOption('_admin_route', TRUE);
-
-      return $route;
     }
+
+    return $route ?? NULL;
   }
 
   /**
@@ -116,9 +117,9 @@ class GpHtmlRouteProvider extends AdminHtmlRouteProvider {
         ])
         ->setRequirement('_permission', 'revert all gp revisions')
         ->setOption('_admin_route', TRUE);
-
-      return $route;
     }
+
+    return $route ?? NULL;
   }
 
   /**
@@ -140,9 +141,9 @@ class GpHtmlRouteProvider extends AdminHtmlRouteProvider {
         ])
         ->setRequirement('_permission', 'delete all gp revisions')
         ->setOption('_admin_route', TRUE);
-
-      return $route;
     }
+
+    return $route ?? NULL;
   }
 
   /**
@@ -164,9 +165,9 @@ class GpHtmlRouteProvider extends AdminHtmlRouteProvider {
         ])
         ->setRequirement('_permission', 'revert all gp revisions')
         ->setOption('_admin_route', TRUE);
-
-      return $route;
     }
+
+    return $route ?? NULL;
   }
 
   /**
@@ -188,9 +189,9 @@ class GpHtmlRouteProvider extends AdminHtmlRouteProvider {
         ])
         ->setRequirement('_permission', $entity_type->getAdminPermission())
         ->setOption('_admin_route', TRUE);
-
-      return $route;
     }
+
+    return $route ?? NULL;
   }
 
 }

--- a/nidirect_gp/src/Plugin/Validation/Constraint/GpUniqueCypherConstraint.php
+++ b/nidirect_gp/src/Plugin/Validation/Constraint/GpUniqueCypherConstraint.php
@@ -20,6 +20,16 @@ class GpUniqueCypherConstraint extends Constraint {
    *
    * @var string
    */
-  public $message = "A GP entry with the cypher '@cypher' exists. A GP must have a unique cypher.";
+  protected $message = "A GP entry with the cypher '@cypher' exists. A GP must have a unique cypher.";
+
+  /**
+   * Returns the constraint message.
+   *
+   * @return string
+   *   The contraint message.
+   */
+  public function getMessage() :string {
+    return $this->message;
+  }
 
 }

--- a/nidirect_gp/src/Plugin/Validation/Constraint/GpUniqueCypherConstraintValidator.php
+++ b/nidirect_gp/src/Plugin/Validation/Constraint/GpUniqueCypherConstraintValidator.php
@@ -48,8 +48,9 @@ class GpUniqueCypherConstraintValidator extends ConstraintValidator implements C
       return;
     }
 
+    /** @var \Drupal\nidirect_gp\Plugin\Validation\Constraint\GpUniqueCypherConstraint $constraint */
     if ($this->uniqueCypherService->isCypherUnique($cypher, [$entity->id()]) === FALSE) {
-      $this->context->addViolation($constraint->message, ['@cypher' => $cypher]);
+      $this->context->addViolation($constraint->getMessage(), ['@cypher' => $cypher]);
     }
   }
 

--- a/nidirect_gp/tests/src/Functional/GPPracticeTest.php
+++ b/nidirect_gp/tests/src/Functional/GPPracticeTest.php
@@ -32,7 +32,7 @@ class GPPracticeTest extends BrowserTestBase {
   /**
    * Use install profile so that we have all content types, modules etc.
    *
-   * @var installprofile
+   * @var string
    */
   protected $profile = 'test_profile';
 

--- a/nidirect_gp/tests/src/Kernel/GPPracticeTest.php
+++ b/nidirect_gp/tests/src/Kernel/GPPracticeTest.php
@@ -21,9 +21,9 @@ class GPPracticeTest extends EntityKernelTestBase {
   public static $modules = ['node', 'nidirect_gp', 'nidirect_common'];
 
   /**
-   * Test setup function.
+   * {@inheritdoc}
    */
-  public function setUp() {
+  public function setUp(): void {
     parent::setUp();
 
     $this->installConfig('nidirect_gp');

--- a/nidirect_health_conditions/nidirect_health_conditions.module
+++ b/nidirect_health_conditions/nidirect_health_conditions.module
@@ -102,12 +102,14 @@ function nidirect_health_conditions_views_pre_render(ViewExecutable $view) {
  */
 function nidirect_health_conditions_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
   if ($view->id() == 'health_conditions_a_to_z' && $view->current_display == 'health_conditions_by_letter') {
-    // where[0] refers to the contextual filter, but the out-of-the-box options
-    // doesn't permit a 'LIKE' comparison. So we adjust it here to pass the
-    // controller's parameter for letter into the view and let it do the heavy
-    // lifting of the query.
-    $query->where[0]['conditions'][0]['value'] .= '%';
-    $query->where[0]['conditions'][0]['operator'] = 'LIKE';
+    if (!empty($query->where)) {
+      // where[0] refers to the contextual filter, but the out-of-the-box options
+      // doesn't permit a 'LIKE' comparison. So we adjust it here to pass the
+      // controller's parameter for letter into the view and let it do the heavy
+      // lifting of the query.
+      $query->where[0]['conditions'][0]['value'] .= '%';
+      $query->where[0]['conditions'][0]['operator'] = 'LIKE';
+    }
   }
 }
 
@@ -260,6 +262,7 @@ function nidirect_health_conditions_entity_prepare_form(EntityInterface $entity,
     $term = reset($result);
 
     if ($term instanceof TermInterface) {
+      /** @var \Drupal\node\NodeInterface $entity */
       $entity->set('field_subtheme', $term->id());
     }
   }

--- a/nidirect_health_conditions/src/Controller/HealthConditionsListingController.php
+++ b/nidirect_health_conditions/src/Controller/HealthConditionsListingController.php
@@ -5,7 +5,6 @@ namespace Drupal\nidirect_health_conditions\Controller;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Block\BlockManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Tests\rest\Functional\ResourceTest;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -31,7 +30,7 @@ class HealthConditionsListingController extends ControllerBase {
   /**
    * Symfony\Component\HttpFoundation\RequestStack definition.
    *
-   * @var Symfony\Component\HttpFoundation\RequestStack
+   * @var \Symfony\Component\HttpFoundation\RequestStack
    */
   protected $request;
 

--- a/nidirect_health_conditions/src/Plugin/Block/HealthConditionsAzBlock.php
+++ b/nidirect_health_conditions/src/Plugin/Block/HealthConditionsAzBlock.php
@@ -24,9 +24,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class HealthConditionsAzBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
   /**
-   * Drupal\Core\Routing\CurrentRouteMatch definition.
+   * \Drupal\Core\Routing\CurrentRouteMatch definition.
    *
-   * @var Drupal\Core\Routing\CurrentRouteMatch
+   * @var \Drupal\Core\Routing\CurrentRouteMatch
    */
   protected $routeMatch;
 
@@ -39,7 +39,7 @@ class HealthConditionsAzBlock extends BlockBase implements ContainerFactoryPlugi
    *   The plugin id.
    * @param mixed $plugin_definition
    *   Plugin definition.
-   * @param Drupal\Core\Routing\CurrentRouteMatch $route_match
+   * @param \Drupal\Core\Routing\CurrentRouteMatch $route_match
    *   Route match object.
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, CurrentRouteMatch $route_match) {

--- a/nidirect_health_conditions/src/Plugin/Block/RelatedConditionsBlock.php
+++ b/nidirect_health_conditions/src/Plugin/Block/RelatedConditionsBlock.php
@@ -29,23 +29,23 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class RelatedConditionsBlock extends BlockBase implements ContainerFactoryPluginInterface {
 
   /**
-   * Drupal\Core\Routing\CurrentRouteMatch definition.
+   * \Drupal\Core\Routing\CurrentRouteMatch definition.
    *
-   * @var Drupal\Core\Routing\CurrentRouteMatch
+   * @var \Drupal\Core\Routing\CurrentRouteMatch
    */
   protected $routeMatch;
 
   /**
    * Entity type manager service.
    *
-   * @var Drupal\Core\Entity\EntityTypeManagerInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityTypeManager;
 
   /**
    * Node to use.
    *
-   * @var Drupal\node\NodeInterface
+   * @var \Drupal\node\NodeInterface
    */
   protected $node;
 
@@ -58,9 +58,9 @@ class RelatedConditionsBlock extends BlockBase implements ContainerFactoryPlugin
    *   The plugin id.
    * @param mixed $plugin_definition
    *   Plugin definition.
-   * @param Drupal\Core\Routing\CurrentRouteMatch $route_match
+   * @param \Drupal\Core\Routing\CurrentRouteMatch $route_match
    *   Route match object.
-   * @param Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   Entity type manager service.
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, CurrentRouteMatch $route_match, EntityTypeManagerInterface $entity_type_manager) {

--- a/nidirect_landing_pages/nidirect_landing_pages.module
+++ b/nidirect_landing_pages/nidirect_landing_pages.module
@@ -12,6 +12,7 @@ use Drupal\Core\Link;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
 use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
 use Drupal\paragraphs\Entity\Paragraph;
 use Drupal\redirect\Entity\Redirect;
 use Drupal\taxonomy\Entity\Term;
@@ -210,14 +211,17 @@ function nidirect_landing_pages_process_format($element) {
  */
 function nidirect_landing_pages_entity_presave(EntityInterface $entity) {
   // This will fire when nodes are created or edited.
-  if ($entity->getEntityTypeId() == 'block_content') {
+  if ($entity->getEntityTypeId() === 'block_content') {
+    /** @var \Drupal\block_content\BlockContentInterface $entity */
     if ($entity->hasField('field_manually_control_listing')) {
       $manual_field = $entity->get('field_manually_control_listing');
       if ($manual_field->getValue()[0]['value'] == 0) {
         // Update the list of teasers on every save if manual
         // control has not been selected.
+        $results = [];
+
         $node = \Drupal::routeMatch()->getParameter('node');
-        if (is_object($node) && !empty($node->field_subtheme->target_id)) {
+        if ($node instanceof NodeInterface && !empty($node->field_subtheme->target_id)) {
           // Get a list of article teasers by term.
           if (!empty($node->id())) {
             $results = _retrieve_article_teasers_by_term($node->field_subtheme->target_id, $node->id());
@@ -403,7 +407,7 @@ function nidirect_landing_pages_get_redirect_url(string $source_path) {
  *   The landing page node entity.
  */
 function nidirect_landing_pages_create_theme_to_landing_page_redirect(EntityInterface $entity) {
-
+  /** @var \Drupal\node\NodeInterface $entity */
   // Determine the theme path that will be the redirect source.
   $subtheme_tid = $entity->get('field_subtheme')->getString();
   $taxonomy_term_path = 'taxonomy/term/' . $subtheme_tid;
@@ -454,6 +458,8 @@ function nidirect_landing_pages_create_theme_to_landing_page_redirect(EntityInte
  *   The landing page node.
  */
 function nidirect_landing_pages_delete_theme_to_landing_page_redirect(EntityInterface $entity) {
+  /** @var \Drupal\node\NodeInterface $entity */
+
   $redirect_repository = \Drupal::service('redirect.repository');
 
   // The redirect to delete must have a source path that matches
@@ -533,7 +539,7 @@ function _render_article_teasers_auto(array &$variables) {
       }
     }
   }
-  if (is_object($node) && !empty($node->field_subtheme->target_id)) {
+  if ($node instanceof NodeInterface && !empty($node->field_subtheme->target_id)) {
     // Add custom cache tag for taxonomy term listing.
     $cache_tags[] = 'taxonomy_term_list:' . $node->field_subtheme->target_id;
     // Get a list of article teasers by term.
@@ -589,26 +595,24 @@ function _render_article_teasers_manual_control(array &$variables) {
 function _render_article_teaser(Paragraph $paragraph, array &$cache_tags) {
   $this_teaser = [];
   $article = $paragraph->get('field_article');
-  if (!empty($article)) {
-    $nid = $article->getValue()[0]['target_id'];
-    // Add cache tag for this article.
-    $cache_tags[] = 'node:' . $nid;
-    $node = Node::load($nid);
-    if (!empty($node)) {
-      $this_teaser['title_link'] = [
-        '#type' => 'link',
-        '#title' => $node->getTitle(),
-        '#url' => Url::fromRoute('entity.node.canonical', ['node' => $nid]),
-      ];
-      $this_teaser['more_link'] = [
-        '#type' => 'link',
-        '#title' => '... ' . t('more'),
-        '#url' => Url::fromRoute('entity.node.canonical', ['node' => $nid]),
-      ];
-      $this_teaser['summary_text'] = '';
-      if ($node->hasField('field_summary')) {
-        $this_teaser['summary_text'] = ['#markup' => $node->get('field_summary')->getValue()[0]['value']];
-      }
+  $nid = $article->getValue()[0]['target_id'];
+  // Add cache tag for this article.
+  $cache_tags[] = 'node:' . $nid;
+  $node = Node::load($nid);
+  if (!empty($node)) {
+    $this_teaser['title_link'] = [
+      '#type' => 'link',
+      '#title' => $node->getTitle(),
+      '#url' => Url::fromRoute('entity.node.canonical', ['node' => $nid]),
+    ];
+    $this_teaser['more_link'] = [
+      '#type' => 'link',
+      '#title' => '... ' . t('more'),
+      '#url' => Url::fromRoute('entity.node.canonical', ['node' => $nid]),
+    ];
+    $this_teaser['summary_text'] = '';
+    if ($node->hasField('field_summary')) {
+      $this_teaser['summary_text'] = ['#markup' => $node->get('field_summary')->getValue()[0]['value']];
     }
   }
   return $this_teaser;

--- a/nidirect_landing_pages/src/Controller/LandingPagesChooseSectionController.php
+++ b/nidirect_landing_pages/src/Controller/LandingPagesChooseSectionController.php
@@ -67,6 +67,8 @@ class LandingPagesChooseSectionController implements ContainerInjectionInterface
     $items = [];
     $definitions = $this->layoutManager->getFilteredDefinitions('layout_builder', $this->getPopulatedContexts($section_storage), ['section_storage' => $section_storage]);
     foreach ($definitions as $plugin_id => $definition) {
+      /** @var \Drupal\Core\Layout\LayoutDefinition $definition */
+
       $layout = $this->layoutManager->createInstance($plugin_id);
       $item = [
         '#type' => 'link',

--- a/nidirect_money_advice_articles/src/EventSubscriber/PostMigrationSubscriber.php
+++ b/nidirect_money_advice_articles/src/EventSubscriber/PostMigrationSubscriber.php
@@ -17,9 +17,9 @@ use Drupal\Core\Logger\LoggerChannelFactory;
 class PostMigrationSubscriber implements EventSubscriberInterface {
 
   /**
-   * Drupal\Core\Logger\LoggerChannelFactory definition.
+   * Drupal\Core\Logger\LoggerChannel definition.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelFactory
+   * @var \Drupal\Core\Logger\LoggerChannel
    */
   protected $logger;
 

--- a/nidirect_money_advice_articles/tests/src/Kernel/ArticleProcessorsTest.php
+++ b/nidirect_money_advice_articles/tests/src/Kernel/ArticleProcessorsTest.php
@@ -37,9 +37,9 @@ class ArticleProcessorsTest extends KernelTestBase {
   ];
 
   /**
-   * Test setup function.
+   * {@inheritdoc}
    */
-  public function setUp() {
+  public function setUp(): void {
     parent::setUp();
 
     $this->installConfig(['nidirect_money_advice_articles']);

--- a/nidirect_news/src/Controller/NewsListingController.php
+++ b/nidirect_news/src/Controller/NewsListingController.php
@@ -3,7 +3,6 @@
 namespace Drupal\nidirect_news\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
-use Drupal\metatag\MetatagTagPluginManager;
 use Drupal\nidirect_common\ViewsMetatagManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
@@ -97,7 +96,9 @@ class NewsListingController extends ControllerBase {
 
         // Extract row node ids for exclusion in 'older news' embed display below.
         foreach ($view->result as $index => $row) {
-          $latest_news_nids[] = $row->nid;
+          if (!empty($row->nid)) {
+            $latest_news_nids[] = $row->nid;
+          }
         }
       }
 
@@ -166,7 +167,9 @@ class NewsListingController extends ControllerBase {
     $nids = [];
 
     foreach ($view->result as $row) {
-      $nids[] = $row->nid;
+      if (!empty($row->nid)) {
+        $nids[] = $row->nid;
+      }
     }
 
     return $nids;

--- a/nidirect_news/src/Plugin/Block/FeaturedNewsBlock.php
+++ b/nidirect_news/src/Plugin/Block/FeaturedNewsBlock.php
@@ -21,7 +21,7 @@ class FeaturedNewsBlock extends BlockBase implements ContainerFactoryPluginInter
   /**
    * The news controller service.
    *
-   * @var Drupal\nidirect_news\Controller\NewsListingController
+   * @var \Drupal\nidirect_news\Controller\NewsListingController
    */
   protected $newsService;
 

--- a/nidirect_related_content/nidirect_related_content.module
+++ b/nidirect_related_content/nidirect_related_content.module
@@ -35,6 +35,9 @@ function nidirect_related_content_views_pre_build(ViewExecutable $view) {
       return [];
     }
 
+    $sub_theme = 'all';
+    $site_themes = 'all';
+
     if (!empty($node->field_subtheme)) {
       $sub_theme = $node->field_subtheme->target_id ?? 'all';
       $site_themes = $node->field_site_themes->target_id ?? 'all';
@@ -47,7 +50,7 @@ function nidirect_related_content_views_pre_build(ViewExecutable $view) {
 
     // If it's an editorially privileged user account, remove
     // the hidden flag filters. Catchily named 'flagged_1' and 'flagged_2'
-    // by flag modoule, one for each filter group defined in the views UI.
+    // by flag module, one for each filter group defined in the views UI.
     if (\Drupal::currentUser()->hasPermission('administer nodes')) {
       foreach (['flagged_1', 'flagged_2'] as $filter_id) {
         if (!empty($view->filter[$filter_id])) {

--- a/nidirect_related_content/src/RelatedContentManager.php
+++ b/nidirect_related_content/src/RelatedContentManager.php
@@ -318,7 +318,7 @@ class RelatedContentManager {
 
       // If we are dealing with a book entry and it's lower than the first page,
       // don't add to the list of articles for the taxonomy term.
-      if (!empty($entity->book) && $entity->book['depth'] > 1) {
+      if (!empty($entity->book) && ($entity->book['depth'] ?? 0) > 1) {
         continue;
       }
 

--- a/nidirect_related_content/src/RelatedContentManager.php
+++ b/nidirect_related_content/src/RelatedContentManager.php
@@ -8,7 +8,6 @@ use Drupal\Core\Routing\CurrentRouteMatch;
 use Drupal\Core\Url;
 use Drupal\flag\FlagService;
 use Drupal\taxonomy\TermInterface;
-use Drupal\views\Views;
 
 /**
  * Provides methods for managing related content display.
@@ -313,25 +312,34 @@ class RelatedContentManager {
     $rows = array_merge($parent_rows, $supplementary_rows);
 
     foreach ($rows as $row) {
+
+      /** @var \Drupal\node\NodeInterface $entity */
+      $entity = $row->_entity;
+
       // If we are dealing with a book entry and it's lower than the first page,
       // don't add to the list of articles for the taxonomy term.
-      if (!empty($row->_entity->book) && $row->_entity->book['depth'] > 1) {
+      if (!empty($entity->book) && $entity->book['depth'] > 1) {
         continue;
       }
 
       // External link nodes' titles should be replaced with the link value
       // they contain.
-      if ($row->_entity->bundle() === 'external_link') {
-        $title = $row->_entity->field_link->title;
-        $url = Url::fromUri($row->_entity->field_link->uri);
+
+      if ($entity->bundle() === 'external_link') {
+        /** @var \Drupal\link\Plugin\Field\FieldType\LinkItem $field_link */
+        $field_link = $entity->get('field_link')->first();
+
+        $link_values = $field_link->getValue();
+        $title = $link_values['title'];
+        $url = Url::fromUri($link_values['uri']);
       }
       else {
-        $title = $row->_entity->getTitle();
-        $url = Url::fromRoute('entity.node.canonical', ['node' => $row->nid]);
+        $title = $entity->getTitle();
+        $url = Url::fromRoute('entity.node.canonical', ['node' => $entity->id()]);
       }
 
-      $this->content[$row->_entity->id()] = [
-        'entity' => $row->_entity,
+      $this->content[$entity->id()] = [
+        'entity' => $entity,
         'title' => $title,
         'title_sort' => strtolower($title),
         'url' => $url,
@@ -365,21 +373,25 @@ class RelatedContentManager {
     $rows = array_merge($parent_rows, $supplementary_rows);
 
     foreach ($rows as $row) {
+      /** @var \Drupal\taxonomy\TermInterface $entity */
+      $entity = $row->_entity;
+      $tid = $entity->id();
+
       // Lookup the list of landing/campaign pages for matches against the
       // current row tid. If we get a match, insert a entry for the landing page
       // node and skip adding the term entry.
-      if (array_key_exists($row->tid, $campaign_terms)) {
+      if (array_key_exists($tid, $campaign_terms)) {
         // This will be a link to a campaign (landing page).
-        $this->content[$campaign_terms[$row->tid]->id()] = [
-          'entity' => $campaign_terms[$row->tid],
-          'title' => $campaign_terms[$row->tid]->getTitle(),
-          'title_sort' => strtolower($campaign_terms[$row->tid]->getTitle()),
-          'url' => Url::fromRoute('entity.node.canonical', ['node' => $campaign_terms[$row->tid]->id()]),
+        $this->content[$campaign_terms[$tid]->id()] = [
+          'entity' => $campaign_terms[$tid],
+          'title' => $campaign_terms[$tid]->getTitle(),
+          'title_sort' => strtolower($campaign_terms[$tid]->getTitle()),
+          'url' => Url::fromRoute('entity.node.canonical', ['node' => $campaign_terms[$tid]->id()]),
         ];
         continue;
       }
 
-      $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($row->tid);
+      $term = $this->entityTypeManager->getStorage('taxonomy_term')->load($tid);
       $flags = $this->flagService->getAllEntityFlaggings($term);
 
       if ($flags) {

--- a/nidirect_related_content/tests/src/Kernel/RelatedContentTest.php
+++ b/nidirect_related_content/tests/src/Kernel/RelatedContentTest.php
@@ -73,7 +73,7 @@ class RelatedContentTest extends ViewsKernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public function setUp($import_test_views = TRUE) {
+  public function setUp($import_test_views = TRUE): void {
     parent::setUp($import_test_views);
 
     $this->installConfig(['nidirect_related_content']);

--- a/nidirect_school_closures/src/SchoolClosuresServiceInterface.php
+++ b/nidirect_school_closures/src/SchoolClosuresServiceInterface.php
@@ -27,7 +27,7 @@ interface SchoolClosuresServiceInterface {
   /**
    * Returns last updated date.
    *
-   * @return DateTime
+   * @return \DateTime
    *   A DateTime of when the closures data was last updated.
    */
   public function getUpdated();

--- a/nidirect_school_closures/src/Service/C2kschoolsSchoolClosuresService.php
+++ b/nidirect_school_closures/src/Service/C2kschoolsSchoolClosuresService.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\nidirect_school_closures\Service;
 
-use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Exception\ClientException;
 use Drupal\nidirect_school_closures\SchoolClosuresServiceInterface;
 use Drupal\nidirect_school_closures\SchoolClosure;
@@ -46,7 +46,7 @@ class C2kschoolsSchoolClosuresService implements SchoolClosuresServiceInterface 
   /**
    * Parsed XML response from the service call.
    *
-   * @var SimpleXMLElement
+   * @var \SimpleXMLElement
    */
   protected $xml = NULL;
 
@@ -74,14 +74,14 @@ class C2kschoolsSchoolClosuresService implements SchoolClosuresServiceInterface 
   /**
    * When the data was retrived.
    *
-   * @var DateTime
+   * @var \DateTime
    */
   protected $updated;
 
   /**
-   * GuzzleHttp\ClientInterface definition.
+   * GuzzleHttp\Client definition.
    *
-   * @var \GuzzleHttp\ClientInterface
+   * @var \GuzzleHttp\Client
    */
   protected $httpClient;
 
@@ -93,16 +93,16 @@ class C2kschoolsSchoolClosuresService implements SchoolClosuresServiceInterface 
   protected $cacheService;
 
   /**
-   * Drupal\Core\Logger\LoggerChannelFactory definition.
+   * Logger channel service object.
    *
-   * @var \Drupal\Core\Logger\LoggerChannelFactory
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
    */
   protected $logger;
 
   /**
    * Constructs a new C2kschoolsSchoolClosuresService object.
    */
-  public function __construct(ClientInterface $http_client, CacheBackendInterface $cache, ConfigFactory $config_service, LoggerChannelFactory $logger) {
+  public function __construct(HttpClient $http_client, CacheBackendInterface $cache, ConfigFactory $config_service, LoggerChannelFactory $logger) {
     $this->httpClient = $http_client;
     $this->cacheService = $cache;
     $this->logger = $logger->get('nidirect_school_closures');
@@ -110,17 +110,17 @@ class C2kschoolsSchoolClosuresService implements SchoolClosuresServiceInterface 
     // Fetch the config settings.
     $config = $config_service->get('nidirect_school_closures.settings');
     $this->url = $config->get('data_source_url') ?? $this->url;
-    $this->cacheDuration = $config->get('cache_duration') ?? $this->cacheDurarion;
+    $this->cacheDuration = $config->get('cache_duration') ?? $this->cacheDuration;
     $this->maxAttempts = $config->get('max_attempts') ?? $this->maxAttempts;
   }
 
   /**
    * Last updated date.
    *
-   * @return date
+   * @return \DateTime
    *   Returns dataset last updated date.
    */
-  public function getUpdated() {
+  public function getUpdated(): \DateTime {
     return $this->updated;
   }
 
@@ -130,7 +130,7 @@ class C2kschoolsSchoolClosuresService implements SchoolClosuresServiceInterface 
    * @return array
    *   Returns closures dataset array.
    */
-  public function getData() {
+  public function getData(): array {
     return $this->data;
   }
 
@@ -140,7 +140,7 @@ class C2kschoolsSchoolClosuresService implements SchoolClosuresServiceInterface 
    * @param \SimpleXMLElement $xml
    *   XML Element containing school closure data.
    */
-  public function setXml(\SimpleXMLElement $xml) {
+  public function setXml(\SimpleXMLElement $xml): void {
     $this->xml = $xml;
   }
 
@@ -150,7 +150,7 @@ class C2kschoolsSchoolClosuresService implements SchoolClosuresServiceInterface 
    * @return bool
    *   Returns the current error state.
    */
-  public function hasErrors() {
+  public function hasErrors(): bool {
     return $this->error;
   }
 
@@ -160,7 +160,7 @@ class C2kschoolsSchoolClosuresService implements SchoolClosuresServiceInterface 
    * @return array
    *   closures array.
    */
-  public function getClosures() {
+  public function getClosures(): array {
     // Reset error state.
     $this->error = FALSE;
 
@@ -186,7 +186,7 @@ class C2kschoolsSchoolClosuresService implements SchoolClosuresServiceInterface 
       // Fetch data from the web endpoint.
       $this->fetchData();
 
-      // Process recieved data or attempt again.
+      // Process received data or attempt again.
       if (!empty($this->xml)) {
         $this->processData();
         $this->updated = date('Y-m-d H:i:s');
@@ -214,7 +214,7 @@ class C2kschoolsSchoolClosuresService implements SchoolClosuresServiceInterface 
             $this->getClosures();
           }
           else {
-            // Warn if we can't retrive data from the service or the cache.
+            // Warn if we can't retrieve data from the service or the cache.
             $this->logger->alert('Unable to update school closure data or revert to cached data.');
             $this->error = TRUE;
           }
@@ -240,9 +240,6 @@ class C2kschoolsSchoolClosuresService implements SchoolClosuresServiceInterface 
         }
       }
       catch (ClientException $e) {
-        $this->logger->warning('Failed to fetch school closure data. ' . $e->getMessage());
-      }
-      catch (Exception $e) {
         $this->logger->warning('Failed to fetch school closure data. ' . $e->getMessage());
       }
     }

--- a/nidirect_school_closures/tests/src/Kernel/C2kschoolsSchoolClosuresServiceTest.php
+++ b/nidirect_school_closures/tests/src/Kernel/C2kschoolsSchoolClosuresServiceTest.php
@@ -36,13 +36,12 @@ class C2kschoolsSchoolClosuresServiceTest extends KernelTestBase {
   ];
 
   /**
-   * Test setup function.
+   * {@inheritdoc}
    */
-  public function setUp() {
+  public function setUp(): void {
     parent::setUp();
 
     $this->installConfig(['nidirect_school_closures']);
-
     $this->closureService = \Drupal::service('nidirect_school_closures.source.cskschools');
   }
 

--- a/nidirect_school_closures/tests/src/Kernel/SchoolClosuresTest.php
+++ b/nidirect_school_closures/tests/src/Kernel/SchoolClosuresTest.php
@@ -21,9 +21,9 @@ class SchoolClosuresTest extends KernelTestBase {
   protected $today;
 
   /**
-   * Test setup function.
+   * {@inheritdoc}
    */
-  public function setUp() {
+  public function setUp(): void {
     parent::setUp();
 
     $this->today = new \DateTime('now', new \DateTimeZone('Europe/London'));

--- a/nidirect_search/nidirect_search.module
+++ b/nidirect_search/nidirect_search.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\search_api_solr\Utility\Utility as SolrUtility;
 use Solarium\Core\Query\QueryInterface;
 use Drupal\search_api\Query\QueryInterface as SearchApiQueryInterface;
@@ -81,7 +82,8 @@ function nidirect_search_search_api_solr_query_alter(QueryInterface $solarium_qu
   $search_term = \Drupal::requestStack()->getCurrentRequest()->get($query_id);
 
   // Maps to <str name="name">spelling_und</str> in solrconfig_extra.xml.
-  $solarium_query->getSpellcheck()->setDictionary('spelling_' . Language::LANGCODE_NOT_SPECIFIED);
+  /** @var \Solarium\QueryType\Select\Query\Query $solarium_query */
+  $solarium_query->getSpellcheck()->setDictionary('spelling_' . LanguageInterface::LANGCODE_NOT_SPECIFIED);
   $solarium_query->addParam('spellcheck.onlyMorePopular', FALSE);
   $solarium_query->addParam('spellcheck.extendedResults', FALSE);
   $solarium_query->addParam('spellcheck.count', 1);

--- a/nidirect_search/src/Form/SolrElevatedIdEntityForm.php
+++ b/nidirect_search/src/Form/SolrElevatedIdEntityForm.php
@@ -57,26 +57,29 @@ class SolrElevatedIdEntityForm extends EntityForm {
    */
   public function form(array $form, FormStateInterface $form_state) {
     $form = parent::form($form, $form_state);
+    /** @var \Drupal\nidirect_search\Entity\SolrElevatedIdEntity $entity */
+    $entity = $this->entity;
 
     $form['label'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Search term'),
       '#maxlength' => 255,
-      '#default_value' => $this->entity->label(),
+      '#default_value' => $entity->label(),
       '#description' => $this->t('Search term to define elevations for.'),
       '#required' => TRUE,
     ];
 
     $form['id'] = [
       '#type' => 'machine_name',
-      '#default_value' => $this->entity->id(),
+      '#default_value' => $entity->id(),
       '#machine_name' => [
         'exists' => '\Drupal\nidirect_search\Entity\SolrElevatedIdEntity::load',
       ],
-      '#disabled' => !$this->entity->isNew(),
+      '#disabled' => !$entity->isNew(),
     ];
 
     // Construct the index options by fetching the current Solr server indexes.
+    $index_options = [];
     foreach ($this->solrServer->getIndexes() as $id => $index) {
       $index_options[$id] = $index->label();
     }
@@ -85,7 +88,7 @@ class SolrElevatedIdEntityForm extends EntityForm {
       '#type' => 'select',
       '#title' => $this->t('Search index'),
       '#options' => $index_options,
-      '#default_value' => $this->entity->index(),
+      '#default_value' => $entity->index(),
       '#description' => $this->t('Solr search index to elevate against.'),
       '#required' => TRUE,
     ];
@@ -94,7 +97,7 @@ class SolrElevatedIdEntityForm extends EntityForm {
       '#type' => 'textfield',
       '#title' => $this->t('Nodes'),
       '#maxlength' => 255,
-      '#default_value' => $this->entity->nodes(),
+      '#default_value' => $entity->nodes(),
       '#description' => $this->t('Comma separated node ids to elevate for this search term'),
       '#placeholder' => 'e.g. 1, 1021, 67',
       '#required' => TRUE,
@@ -103,7 +106,7 @@ class SolrElevatedIdEntityForm extends EntityForm {
     $form['status'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Enabled'),
-      '#default_value' => ($this->entity->isNew()) ? TRUE : $this->entity->status(),
+      '#default_value' => ($entity->isNew()) ? TRUE : $entity->status(),
     ];
 
     return $form;
@@ -150,6 +153,9 @@ class SolrElevatedIdEntityForm extends EntityForm {
    */
   public function save(array $form, FormStateInterface $form_state) {
     $result = parent::save($form, $form_state);
+    $index = '';
+    $label = '';
+
     extract($form_state->getValues());
 
     $message = $result === SAVED_NEW

--- a/nidirect_search/src/SolrElevatedIdEntityListBuilder.php
+++ b/nidirect_search/src/SolrElevatedIdEntityListBuilder.php
@@ -40,6 +40,7 @@ class SolrElevatedIdEntityListBuilder extends ConfigEntityListBuilder {
    * {@inheritdoc}
    */
   public function buildRow(EntityInterface $entity) {
+    /** @var \Drupal\nidirect_search\Entity\SolrElevatedIdEntity $entity */
     $row['label'] = $entity->label();
     $row['id'] = $entity->index();
     $row['status'] = $entity->status() ? $this->t('Enabled') : $this->t('Disabled');

--- a/nidirect_taxonomy_navigator/src/Controller/TaxonomyNavigatorController.php
+++ b/nidirect_taxonomy_navigator/src/Controller/TaxonomyNavigatorController.php
@@ -157,6 +157,7 @@ class TaxonomyNavigatorController extends ControllerBase {
     $ids = $query->execute();
     $terms = $ids ? $termStorage->loadMultiple($ids) : [];
 
+    $results = [];
     foreach ($terms as $term) {
 
       $results[] = [

--- a/nidirect_taxonomy_navigator/src/Form/SetParentTermForm.php
+++ b/nidirect_taxonomy_navigator/src/Form/SetParentTermForm.php
@@ -4,7 +4,7 @@ namespace Drupal\nidirect_taxonomy_navigator\Form;
 
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Symfony\Cmf\Component\Routing\RouteObjectInterface;
+use Drupal\Core\Routing\RouteObjectInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**

--- a/nidirect_taxonomy_navigator/src/Form/SetParentTermForm.php
+++ b/nidirect_taxonomy_navigator/src/Form/SetParentTermForm.php
@@ -58,6 +58,7 @@ class SetParentTermForm extends FormBase {
     $term_tree = $this->entityTypeManager->getStorage('taxonomy_term')->loadTree($term->bundle());
 
     // Build our select options array vid => name.
+    $terms = [];
     foreach ($term_tree as $tree_term) {
       $terms[$tree_term->tid] = $tree_term->name;
     }

--- a/nidirect_webforms/src/Plugin/WebformHandler/NIDirectQuizResultsHandler.php
+++ b/nidirect_webforms/src/Plugin/WebformHandler/NIDirectQuizResultsHandler.php
@@ -94,7 +94,13 @@ class NIDirectQuizResultsHandler extends WebformHandlerBase {
       '#min' => 0,
     ];
 
-    $webform_elements = $form_state->getFormObject()->getWebform()->getElementsDecodedAndFlattened();
+    /** @var \Drupal\Core\Form\FormStateInterface $form_object */
+    $form_object = $form_state->getFormObject();
+    /** @var \Drupal\webform_ui\Form\WebformUiElementFormInterface $form_object */
+    $webform = $form_object->getWebform();
+    /** @var \Drupal\webform\WebformInterface $webform */
+    $webform_elements = $webform->getElementsDecodedAndFlattened();
+
     $webform_questions = [];
     $multiple_answers = FALSE;
 


### PR DESCRIPTION
TL;DR:

* Many classes have property namespaces missing a `\` prefix. NB: not required in the `Use` statements.
* Lots of type hinting now in place to guide the IDE/static analysis tool (phpstan) to assess what functions/properties are available for use.
* Reduction in magic methods (`$node->field_body->value`) which, while functional (for now) make it impossible to see the contents until runtime.
* Two cases of ignoring phpstan, because I can't work out what type the next thing should be considered even from the class reflection/inspection. :man_shrugging: 