### PR TITLE
Log a warning if missing breadcrumb is detected on a node

### DIFF
--- a/nidirect_breadcrumbs/nidirect_breadcrumbs.module
+++ b/nidirect_breadcrumbs/nidirect_breadcrumbs.module
@@ -52,10 +52,8 @@ function nidirect_breadcrumbs_preprocess_breadcrumb(&$variables) {
 
   if (\Drupal::state()->get('missing_breadcrumb_check') !== 1) {
     $route_match = \Drupal::routeMatch();
-    // Log a warning if a node has no breadcrumb trail.
     if ($route_match->getRouteName() == 'entity.node.canonical') {
       $node = $route_match->getParameter('node');
-      // Log a warning if a node has no breadcrumb trail and
       if (empty($variables['breadcrumb'])) {
         \Drupal::logger('nidirect_breadcrumbs')
           ->warning('Breadcrumb missing for node @node', ['@node' => $node->id()]);

--- a/nidirect_breadcrumbs/nidirect_breadcrumbs.module
+++ b/nidirect_breadcrumbs/nidirect_breadcrumbs.module
@@ -50,17 +50,15 @@ function nidirect_breadcrumbs_preprocess_breadcrumb(&$variables) {
   // If a node is found to have a missing breadcrumb, log a warning and
   // prevent further checks being made.
 
-  if (\Drupal::state()->get('missing_breadcrumb_check') !== 1) {
+  if (empty($variables['breadcrumb']) && \Drupal::state()->get('missing_breadcrumb_check') !== 1) {
     $route_match = \Drupal::routeMatch();
-    if ($route_match->getRouteName() == 'entity.node.canonical') {
-      $node = $route_match->getParameter('node');
-      if (empty($variables['breadcrumb'])) {
-        \Drupal::logger('nidirect_breadcrumbs')
-          ->warning('Breadcrumb missing for node @node', ['@node' => $node->id()]);
-        \Drupal::state()->set('missing_breadcrumb_check', 1);
-
-        // @TODO add code to help debug why breadcrumb is missing for this node.
-      }
+    if ($route_match->getRouteName() === 'entity.node.canonical') {
+      \Drupal::logger('nidirect_breadcrumbs')
+        ->warning('nid @node missing breadcrumb: <br /><code>@variables</code>', [
+          '@node' => $route_match->getParameter('node')->id(),
+          '@variables' => serialize($variables),
+        ]);
+      \Drupal::state()->set('missing_breadcrumb_check', 1);
     }
   }
 }

--- a/nidirect_breadcrumbs/nidirect_breadcrumbs.module
+++ b/nidirect_breadcrumbs/nidirect_breadcrumbs.module
@@ -41,3 +41,28 @@ function nidirect_breadcrumbs_preview_cache_handler(array &$form, FormStateInter
   }
 
 }
+
+/**
+ * Implements hook_preprocess_breadcrumb().
+ */
+function nidirect_breadcrumbs_preprocess_breadcrumb(&$variables) {
+  // Check for missing breadcrumb on nodes.
+  // If a node is found to have a missing breadcrumb, log a warning and
+  // prevent further checks being made.
+
+  if (\Drupal::state()->get('missing_breadcrumb_check') !== 1) {
+    $route_match = \Drupal::routeMatch();
+    // Log a warning if a node has no breadcrumb trail.
+    if ($route_match->getRouteName() == 'entity.node.canonical') {
+      $node = $route_match->getParameter('node');
+      // Log a warning if a node has no breadcrumb trail and
+      if (empty($variables['breadcrumb'])) {
+        \Drupal::logger('nidirect_breadcrumbs')
+          ->warning('Breadcrumb missing for node @node', ['@node' => $node->id()]);
+        \Drupal::state()->set('missing_breadcrumb_check', 1);
+
+        // @TODO add code to help debug why breadcrumb is missing for this node.
+      }
+    }
+  }
+}


### PR DESCRIPTION
The mystery of the disappearing breadcrumb trail continues.  Had another incident yesterday where a user reported it was missing.  I tried downloading the db and importing locally - but the trail worked ok. 

Hoping this hook_preprocess_breadcrumb will log an error as soon as breadcrumbs start to disappear on live nodes. I can get logz.io to send an email alert if a log entry about missing breadcrumbs appears ... That's the theory anyway!

Can maybe expand this with additional code to troubleshoot why the breadcrumb is missing?