### PR TITLE
Remove uri query param from translation help link and allow block to be cached

### DIFF
--- a/nidirect_common/src/Plugin/Block/TranslationHelpBlock.php
+++ b/nidirect_common/src/Plugin/Block/TranslationHelpBlock.php
@@ -81,10 +81,6 @@ class TranslationHelpBlock extends BlockBase implements ContainerFactoryPluginIn
     ];
 
     if ($translation_help_url) {
-      // Get the currently requested uri and add as query param to translation help url.
-      $uri = $this->requestStack->getCurrentRequest()->getRequestUri();
-      $translation_help_url->setOption('query', ['uri' => $uri]);
-
       // Add translation help link to block content.
       $block_content['translation-help-link'] = [
         '#type' => 'link',
@@ -104,14 +100,6 @@ class TranslationHelpBlock extends BlockBase implements ContainerFactoryPluginIn
 
     return $block_content;
 
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function getCacheMaxAge() {
-    // The output for this block differs on every page - so don't cache it.
-    return 0;
   }
 
 }


### PR DESCRIPTION
The URI query parameter on the translation help link is not required.  The translation help page JS retrieves the URI to be translated from document.referrer - it does not use the query param.

The presence of the param means the translation help block cannot be cached. It also causes 1000s of unique requests for the translation help page because the page is not being retrieved from Drupal's page cache. 