### PR TITLE
Update nidirect_common.module

### DIFF
--- a/nidirect_common/nidirect_common.module
+++ b/nidirect_common/nidirect_common.module
@@ -413,12 +413,23 @@ function nidirect_common_clientside_validation_should_validate($element, FormSta
  * Implements hook_form_BASE_FORM_ID_alter().
  */
 function nidirect_common_form_system_performance_settings_alter(&$form, FormStateInterface $form_state, $form_id) {
-  // Alter the system performance admin screen so that a 'Browser and proxy
-  // cache maximum age' of 1 year may be selected.
-  // Also add an informative suffix to make it clear that this has been done.
-  $form['caching']['page_cache_maximum_age']['#options'][31536000] = t("1 year");
-  $form['caching']['page_cache_maximum_age']['#suffix'] = t("<i>@suffix</i>",
-    ['@suffix' => "Note that Drupal core settings have been customised here for NIDirect to allow for a maximum age of 1 year"]);
+  // Http_cache_control contrib module 'Surrogate max age' options.
+  // These control how long Fastly will cache a page (by setting the
+  // Surrogate-Control header). We want additional options to cache pages for
+  // longer periods than 1 day.
+  if (!empty($form['surrogate']['surrogate_maxage'])) {
+    $form['surrogate']['surrogate_maxage']['#options'] += [
+      604800 => t("1 week")->render(),
+      2628000 => t("1 month")->render(),
+      7884000 => t("3 months")->render(),
+      15768000 => t("6 months")->render(),
+      31536000 => t("1 year")->render(),
+    ];
+
+    // Make it clear that this has been done.
+    $form['surrogate']['surrogate_maxage']['#suffix'] = t("<i>@suffix</i>",
+      ['@suffix' => "HTTP_cache_control contrib module settings have been customised here to enable surrogate max age of up to 1 year"]);
+  }
 }
 
 /**


### PR DESCRIPTION
Add additional surrogate max age options to enable Fastly to cache pages for up to one year. 