### PR TITLE
Hide book nav on landing pages

### DIFF
--- a/nidirect_landing_pages/nidirect_landing_pages.module
+++ b/nidirect_landing_pages/nidirect_landing_pages.module
@@ -723,3 +723,22 @@ function nidirect_landing_pages_render_article_teasers_by_topic(int $tid, array 
   }
   return $results;
 }
+
+
+/**
+ * Implements template_preprocess_book_navigation().
+ */
+function nidirect_landing_pages_preprocess_book_navigation(&$variables) {
+  $node = \Drupal::routeMatch()->getParameter('node');
+
+  if ($node instanceof NodeInterface && $node->bundle() == 'landing_page') {
+
+    // Hide book navigation on landing pages that are the first page of a book.
+    if ($node->book && $node->book['depth'] == 1) {
+      // Remove list of book contents
+      unset($variables['tree']);
+      // Hide previous/next book links.
+      $variables['has_links'] = FALSE;
+    }
+  }
+}

--- a/nidirect_landing_pages/nidirect_landing_pages.module
+++ b/nidirect_landing_pages/nidirect_landing_pages.module
@@ -724,7 +724,6 @@ function nidirect_landing_pages_render_article_teasers_by_topic(int $tid, array 
   return $results;
 }
 
-
 /**
  * Implements template_preprocess_book_navigation().
  */
@@ -735,7 +734,7 @@ function nidirect_landing_pages_preprocess_book_navigation(&$variables) {
 
     // Hide book navigation on landing pages that are the first page of a book.
     if ($node->book && $node->book['depth'] == 1) {
-      // Remove list of book contents
+      // Remove list of book contents.
       unset($variables['tree']);
       // Hide previous/next book links.
       $variables['has_links'] = FALSE;


### PR DESCRIPTION
This is needed for a new Universal Credit (UC) landing page that acts as the front page of a book. Each page in the book presents a video explaining UC.  Since landing pages have a curated layout, we don't want or need the book nav that Drupal automatically adds.